### PR TITLE
Use `pointer` cursor for less obvious clickable UI elements

### DIFF
--- a/src/frontend/running.rs
+++ b/src/frontend/running.rs
@@ -114,6 +114,7 @@ impl Component for RunningView {
                     gtk::Box {
                         gtk::ToggleButton {
                             connect_clicked => RunningInput::ToggleFarmDetails,
+                            set_cursor_from_name: Some("pointer"),
                             set_has_frame: false,
                             set_icon_name: icon_name::GRID_FILLED,
                             set_tooltip: "Expand details about each farm",
@@ -121,6 +122,7 @@ impl Component for RunningView {
                         gtk::ToggleButton {
                             connect_clicked => RunningInput::TogglePausePlotting,
                             set_active: model.plotting_paused,
+                            set_cursor_from_name: Some("pointer"),
                             set_has_frame: false,
                             set_icon_name: icon_name::PAUSE,
                             set_tooltip: "Pause plotting/replotting, note that currently encoding sectors will not be interrupted",
@@ -144,6 +146,7 @@ impl Component for RunningView {
                             //  for macOS
                             connect_clicked => RunningInput::OpenRewardAddressInExplorer,
                             remove_css_class: "link",
+                            set_cursor_from_name: Some("pointer"),
                             set_has_frame: false,
                             set_tooltip: "Total account balance and coins farmed since application started, click to see details in Astral",
                             // TODO: Use LinkButton once https://gitlab.gnome.org/GNOME/glib/-/issues/3403 is fixed

--- a/src/frontend/running/farm.rs
+++ b/src/frontend/running/farm.rs
@@ -136,6 +136,7 @@ impl FactoryComponent for FarmWidget {
                 gtk::Button {
                     add_css_class: "folder-button",
                     connect_clicked => FarmWidgetInput::OpenFarmFolder,
+                    set_cursor_from_name: Some("pointer"),
                     set_halign: gtk::Align::Start,
                     set_has_frame: false,
                     set_tooltip: "Click to open in file manager",

--- a/src/frontend/running/node.rs
+++ b/src/frontend/running/node.rs
@@ -72,6 +72,7 @@ impl Component for NodeView {
                     connect_clicked => NodeInput::OpenNodeFolder,
                     add_css_class: "folder-button",
                     add_css_class: "heading",
+                    set_cursor_from_name: Some("pointer"),
                     set_halign: gtk::Align::Start,
                     set_has_frame: false,
                     #[track = "model.changed_chain_name()"]


### PR DESCRIPTION
Some buttons were not trivial to discover, use `pointer` cursor to indicate that certain area of the UI is clickable