### PR TITLE
Add macOS-specific example paths in configuration

### DIFF
--- a/src/frontend/configuration.rs
+++ b/src/frontend/configuration.rs
@@ -203,6 +203,8 @@ impl AsyncComponent for ConfigurationView {
                                         set_placeholder_text: Some(
                                             if cfg!(windows) {
                                                 "Example: D:\\subspace-node"
+                                            } else if cfg!(macos) {
+                                                "Example: /Volumes/Subspace/subspace-node"
                                             } else {
                                                 "Example: /media/subspace-node"
                                             },

--- a/src/frontend/configuration/farm.rs
+++ b/src/frontend/configuration/farm.rs
@@ -103,6 +103,8 @@ impl AsyncFactoryComponent for FarmWidget {
                             set_placeholder_text: Some(
                                 if cfg!(windows) {
                                     "Example: D:\\subspace-farm"
+                                } else if cfg!(macos) {
+                                    "Example: /Volumes/Farm/subspace-farm"
                                 } else {
                                     "Example: /media/subspace-farm"
                                 },

--- a/src/frontend/configuration/farm.rs
+++ b/src/frontend/configuration/farm.rs
@@ -104,7 +104,7 @@ impl AsyncFactoryComponent for FarmWidget {
                                 if cfg!(windows) {
                                     "Example: D:\\subspace-farm"
                                 } else if cfg!(macos) {
-                                    "Example: /Volumes/Farm/subspace-farm"
+                                    "Example: /Volumes/Subspace/subspace-farm"
                                 } else {
                                     "Example: /media/subspace-farm"
                                 },


### PR DESCRIPTION
This PR adds macOS-specific example paths for the node and farm data.

The paths follow the pattern of Windows and Linux, which are on separate drives.