### PR TITLE
Update Subspace to `gemini-3h-2024-jul-29` release and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,7 +2168,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "domain-block-preprocessor",
  "fp-account",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -2679,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "fixed-hash",
  "fp-account",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-trait",
  "futures",
@@ -9285,7 +9285,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -9318,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "sc-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "sc-client-api",
  "sc-executor",
@@ -9681,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "atomic",
  "core_affinity",
@@ -9913,7 +9913,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 
 [[package]]
 name = "sc-sysinfo"
@@ -10683,7 +10683,7 @@ dependencies = [
 [[package]]
 name = "sp-auto-id"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10707,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "sp-block-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -10801,7 +10801,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-trait",
  "log",
@@ -10937,7 +10937,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-sudo"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10957,7 +10957,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "blake2 0.10.6",
  "domain-runtime-primitives",
@@ -10989,7 +10989,7 @@ dependencies = [
 [[package]]
 name = "sp-domains-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -11024,7 +11024,7 @@ dependencies = [
 [[package]]
 name = "sp-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11115,7 +11115,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -11137,7 +11137,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger-host-functions"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "domain-block-preprocessor",
  "parity-scale-codec",
@@ -11194,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "sp-api",
  "subspace-core-primitives",
@@ -11379,7 +11379,7 @@ dependencies = [
 [[package]]
 name = "sp-subspace-mmr"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11518,7 +11518,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -11727,7 +11727,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -11740,7 +11740,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "blake3",
  "bytes",
@@ -11764,7 +11764,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "kzg",
  "rust-kzg-blst",
@@ -11774,7 +11774,7 @@ dependencies = [
 [[package]]
 name = "subspace-fake-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "domain-runtime-primitives",
  "frame-support",
@@ -11806,7 +11806,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -11867,7 +11867,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -11898,7 +11898,7 @@ dependencies = [
 [[package]]
 name = "subspace-metrics"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "actix-web",
  "prometheus",
@@ -11909,7 +11909,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -11947,7 +11947,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "chacha20",
  "derive_more",
@@ -11962,7 +11962,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "aes",
  "subspace-core-primitives",
@@ -11972,7 +11972,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -11985,7 +11985,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12000,7 +12000,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "async-trait",
  "cross-domain-message-gossip",
@@ -12078,7 +12078,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=0a89bdbeb480ae4446d38b3c06c720f9021858f6#0a89bdbeb480ae4446d38b3c06c720f9021858f6"
+source = "git+https://github.com/subspace/subspace?rev=4de5f0534c6fc377d350b7c97ddaed638fd51fe4#4de5f0534c6fc377d350b7c97ddaed638fd51fe4"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "space-acres"
 description = "Space Acres is an opinionated GUI application for farming on Autonomys Network"
 license = "0BSD"
-version = "0.1.30"
+version = "0.1.31"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/autonomys/space-acres"
 edition = "2021"
@@ -71,14 +71,14 @@ reqwest = { version = "0.12.4", default-features = false, features = ["json", "r
 sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
-sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
+sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
 sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-network-types = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
 sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 schnellru = "0.2.3"
 semver = "1.0.23"
@@ -88,22 +88,22 @@ simple_moving_average = "1.0.2"
 sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
-sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
-sp-objects = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
+sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
+sp-objects = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
 sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
-subspace-fake-runtime-api = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6", default-features = false }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "0a89bdbeb480ae4446d38b3c06c720f9021858f6" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
+subspace-fake-runtime-api = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4", default-features = false }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "4de5f0534c6fc377d350b7c97ddaed638fd51fe4" }
 supports-color = "3.0.0"
 tempfile = "3.10.1"
 thiserror = "1.0.61"


### PR DESCRIPTION
This PR updates Subspace to [`gemini-3h-2024-jul-29`](https://github.com/autonomys/subspace/releases/tag/gemini-3h-2024-jul-29) release and bumps version.