### PR TITLE
Document `librsvg` dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Application supports bare minimum configuration and doesn't support operator fun
 ## How to build
 
 In order to build this app you'll need to install both dependencies necessary for building
-[Subspace](https://github.com/autonomys/subspace) and [GTK4](https://github.com/gtk-rs/gtk4-rs), follow their
-documentation for details, otherwise `cargo run` will get you where to want to be.
+[Subspace](https://github.com/autonomys/subspace) and [GTK4](https://github.com/gtk-rs/gtk4-rs), including the optional
+`librsvg`. Follow their documentation for details, otherwise `cargo run` will get you where to want to be.
 
 ## Contribution
 


### PR DESCRIPTION
`space-acres` needs `librsvg` to show icons.

But `gtk-rs` doesn't explicitly document its optional dependency on `librsvg`, and `cargo build` doesn't install it automatically.