### PR TITLE
Document that Ethernet is preferred over Wifi in INSTALLATION.md

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -37,6 +37,10 @@ redundancy level is 100% pointless too since farms are stateless and can be remo
 on other disks, it'll just make thing slower and reduce effective capacity that can be used for farming, *reducing
 farming rewards for literally no benefit in exchange*.
 
+### Networking
+
+We recommend using a wired Ethernet connection. Some routers and OSes handle large numbers of Wifi connections poorly.
+
 ### Required ports
 
 Application uses **TCP and UDP ports 30333 and 30433** for P2P communication with the rest of the network, both should


### PR DESCRIPTION
As discussed on Slack, some Wifi stacks slow down or hang when making large numbers of connections.

I found this issue on macOS 13.6.7 / MacBook Pro / M1 + Nokia Wifi Beacon 1.1, but other hardware/software combinations are also impacted.