### PR TITLE
Fix some translation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,15 +3243,14 @@ dependencies = [
 [[package]]
 name = "fluent-bundle"
 version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+source = "git+https://github.com/projectfluent/fluent-rs?rev=bda4736095a4a60a9a042b336d0789c22461905d#bda4736095a4a60a9a042b336d0789c22461905d"
 dependencies = [
- "fluent-langneg",
- "fluent-syntax",
+ "fluent-langneg 0.13.0",
+ "fluent-syntax 0.11.1 (git+https://github.com/projectfluent/fluent-rs?rev=bda4736095a4a60a9a042b336d0789c22461905d)",
  "intl-memoizer",
  "intl_pluralrules",
  "rustc-hash",
- "self_cell 0.10.3",
+ "self_cell",
  "smallvec",
  "unic-langid",
 ]
@@ -3263,6 +3262,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94"
 dependencies = [
  "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b2da3cb6583f7e5f98d3e0e1f9ff70451398037445c8e89a0dc51594cf1736"
+dependencies = [
+ "icu_locid",
 ]
 
 [[package]]
@@ -3285,7 +3293,7 @@ dependencies = [
  "accept-language",
  "convert_case 0.6.0",
  "fluent-bundle",
- "fluent-syntax",
+ "fluent-syntax 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -3300,6 +3308,15 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
 dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "git+https://github.com/projectfluent/fluent-rs?rev=bda4736095a4a60a9a042b336d0789c22461905d#bda4736095a4a60a9a042b336d0789c22461905d"
+dependencies = [
+ "memchr",
  "thiserror",
 ]
 
@@ -4660,6 +4677,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4859,8 +4888,7 @@ dependencies = [
 [[package]]
 name = "intl-memoizer"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe22e020fce238ae18a6d5d8c502ee76a52a6e880d99477657e6acc30ec57bda"
+source = "git+https://github.com/projectfluent/fluent-rs?rev=bda4736095a4a60a9a042b336d0789c22461905d#bda4736095a4a60a9a042b336d0789c22461905d"
 dependencies = [
  "type-map",
  "unic-langid",
@@ -6270,6 +6298,12 @@ dependencies = [
  "chacha",
  "keystream",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "litep2p"
@@ -10374,15 +10408,6 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
-dependencies = [
- "self_cell 1.0.4",
-]
-
-[[package]]
-name = "self_cell"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
@@ -11695,7 +11720,7 @@ dependencies = [
  "event-listener-primitives",
  "fdlimit",
  "file-rotate",
- "fluent-langneg",
+ "fluent-langneg 0.14.1",
  "fluent-static",
  "fluent-static-codegen",
  "frame-system",
@@ -14134,6 +14159,12 @@ checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
  "toml 0.5.11",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ duct = "0.13.7"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.3.0"
 file-rotate = "0.7.6"
-fluent-langneg = "0.13.0"
+fluent-langneg = "0.14.1"
 fluent-static = "0.2.4"
 frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
 fs4 = "0.8.4"
@@ -200,6 +200,8 @@ lto = "fat"
 #  are resolved (our fork removes WebRTC support by default in order to avoid OpenSSL dependency)
 [patch.crates-io]
 litep2p = { git = "https://github.com/subspace/litep2p", rev = "331240c0184e9e8939ef9b113963dc58b43e2f92" }
+# TODO: Remove once something newer than 0.15.3 is released with support for `NUMBER()` built-in function and used in `fluent-static`
+fluent-bundle = { git = "https://github.com/projectfluent/fluent-rs", rev = "bda4736095a4a60a9a042b336d0789c22461905d" }
 
 [patch."https://github.com/paritytech/polkadot-sdk.git"]
 # TODO: https://github.com/paritytech/arkworks-substrate depends on Substrate's git commit and requires override

--- a/build.rs
+++ b/build.rs
@@ -5,10 +5,22 @@ use std::{env, fs};
 fn main() {
     // TODO: Workaround for https://github.com/zaytsev/fluent-static/issues/4
     println!("cargo:rerun-if-changed=res/translations");
-
+    let mut generated =
+        generate("res/translations", MessageBundleCodeGenerator::new("en")).unwrap();
+    // This is a hack for making sure `NUMBER()` is supported, see https://github.com/projectfluent/fluent-rs/pull/353#issuecomment-2266336661
+    {
+        if !generated.contains("; bundle }") {
+            panic!("Unexpected generated contents: {generated}");
+        }
+        generated = generated.replace(
+            "; bundle }",
+            // TODO: Should have been `bundle.add_builtins().unwrap();`, but https://github.com/projectfluent/fluent-rs/issues/368
+            r#"; bundle.add_function("NUMBER", super::number).unwrap(); bundle }"#,
+        );
+    }
     fs::write(
         Path::new(&env::var("OUT_DIR").unwrap()).join("l10n.rs"),
-        generate("res/translations", MessageBundleCodeGenerator::new("en")).unwrap(),
+        generated,
     )
     .unwrap();
 

--- a/res/translations/en/messages.ftl
+++ b/res/translations/en/messages.ftl
@@ -91,22 +91,22 @@ running_node_title = {$chain_name} consensus node
 running_node_title_tooltip = Click to open in file manager
 running_node_free_disk_space_tooltip = Free disk space: {$size} remaining
 running_node_status_connecting = Connecting to the network, best block #{$block_number}
-running_node_status_syncing_speed_no_eta = , {NUMBER($blocks_per_second, maximumFractionDigits: 2)} blocks/s
-running_node_status_syncing_speed_hours_eta = , {NUMBER($blocks_per_second, maximumFractionDigits: 2)} blocks/s (~{NUMBER($hours_remaining, maximumFractionDigits: 2)} hours remaining)
-running_node_status_syncing_speed_minutes_eta = , {NUMBER($blocks_per_second, maximumFractionDigits: 2)} blocks/s (~{NUMBER($hours_remaining, maximumFractionDigits: 2)} minutes remaining)
-running_node_status_syncing_speed_seconds_eta = , {NUMBER($blocks_per_second, maximumFractionDigits: 2)} blocks/s (~{NUMBER($hours_remaining, maximumFractionDigits: 2)} seconds remaining)
+running_node_status_syncing_speed_no_eta = , {NUMBER($blocks_per_second, minimumFractionDigits: 2, maximumFractionDigits: 2)} blocks/s
+running_node_status_syncing_speed_hours_eta = , {NUMBER($a_blocks_per_second, minimumFractionDigits: 2, maximumFractionDigits: 2)} blocks/s (~{NUMBER($b_hours_remaining, minimumFractionDigits: 2, maximumFractionDigits: 2)} hours remaining)
+running_node_status_syncing_speed_minutes_eta = , {NUMBER($a_blocks_per_second, minimumFractionDigits: 2, maximumFractionDigits: 2)} blocks/s (~{NUMBER($b_hours_remaining, minimumFractionDigits: 2, maximumFractionDigits: 2)} minutes remaining)
+running_node_status_syncing_speed_seconds_eta = , {NUMBER($a_blocks_per_second, minimumFractionDigits: 2, maximumFractionDigits: 2)} blocks/s (~{NUMBER($b_hours_remaining, minimumFractionDigits: 2, maximumFractionDigits: 2)} seconds remaining)
 running_node_status_syncing =
-    {$sync_kind ->
+    {$a_sync_kind ->
         [dsn] Syncing from DSN
         [regular] Regular sync
-        *[unknown] Unknown sync kind {$sync_kind}
-    } #{$best_block_number}/{$target_block}{$sync_speed}
+        *[unknown] Unknown sync kind {$a_sync_kind}
+    } #{$b_best_block_number}/{$c_target_block}{$d_sync_speed}
 running_node_status_synced = Synced, best block #{$best_block_number}
 running_farmer_title = Farmer
 running_farmer_button_expand_details = Expand details about each farm
 running_farmer_button_pause_plotting = Pause plotting/replotting, note that currently encoding sectors will not be interrupted
 running_farmer_account_balance_tooltip = Total account balance and coins farmed since application started, click to see details in Astral
-running_farmer_piece_cache_sync = Piece cache sync {NUMBER($percentage, maximumFractionDigits: 2)}%
+running_farmer_piece_cache_sync = Piece cache sync {NUMBER($percentage, minimumFractionDigits: 2, maximumFractionDigits: 2)}%
 running_farmer_next_reward_estimate =
     Next reward estimate: {$eta_string ->
         [any_time_now] any time now
@@ -117,27 +117,27 @@ running_farmer_next_reward_estimate =
         *[unknown] unknown
     }
 running_farmer_farm_tooltip = Click to open in file manager
-running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} successful reward signatures, expand farm details to see more information
-running_farmer_farm_auditing_performance_tooltip = Auditing performance: average time {NUMBER($average_time, maximumFractionDigits: 2)}s, time limit {NUMBER($time_timit, maximumFractionDigits: 2)}s
-running_farmer_farm_proving_performance_tooltip = Proving performance: average time {NUMBER($average_time, maximumFractionDigits: 2)}s, time limit {NUMBER($time_timit, maximumFractionDigits: 2)}s
+running_farmer_farm_reward_signatures_tooltip = {$a_successful_signatures}/{$b_total_signatures} successful reward signatures, expand farm details to see more information
+running_farmer_farm_auditing_performance_tooltip = Auditing performance: average time {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, time limit {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
+running_farmer_farm_proving_performance_tooltip = Proving performance: average time {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, time limit {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_non_fatal_error_tooltip = Non-fatal farming error happened and was recovered, see logs for more details: {$error}
 running_farmer_farm_crashed = Farm crashed: {$error}
-running_farmer_farm_plotting_speed =  ({NUMBER($sector_time, maximumFractionDigits: 2)} m/sector, {NUMBER($sectors_per_hour, maximumFractionDigits: 2)} sectors/h)
+running_farmer_farm_plotting_speed =  ({NUMBER($a_sector_time, minimumFractionDigits: 2, maximumFractionDigits: 2)} m/sector, {NUMBER($b_sectors_per_hour, minimumFractionDigits: 2, maximumFractionDigits: 2)} sectors/h)
 running_farmer_farm_plotting_initial =
-    {$pausing_state ->
+    {$a_pausing_state ->
         [pausing] Pausing initial plotting
         [paused] Paused initial plotting
         *[no] Initial plotting
-    } {NUMBER($progress, maximumFractionDigits: 2)}%{$plotting_speed}, {$farming ->
+    } {NUMBER($b_progress, minimumFractionDigits: 2, maximumFractionDigits: 2)}%{$c_plotting_speed}, {$d_farming ->
         [yes] farming
         *[no] not farming
     }
 running_farmer_farm_replotting =
-    {$pausing_state ->
+    {$a_pausing_state ->
         [pausing] Pausing initial plotting
         [paused] Paused initial plotting
-        *[default] Initial plotting
-    } {NUMBER($progress, maximumFractionDigits: 2)}%{$plotting_speed}, {$farming ->
+        *[default] Replotting
+    } {NUMBER($b_progress, minimumFractionDigits: 2, maximumFractionDigits: 2)}%{$c_plotting_speed}, {$d_farming ->
         [yes] farming
         *[no] not farming
     }
@@ -180,5 +180,5 @@ status_bar_button_restart = Restart
 status_bar_button_ok = Ok
 
 about_system_information =
-    Config directory: {$config_directory}
-    Data directory (including logs): {$data_directory}
+    Config directory: {$a_config_directory}
+    Data directory (including logs): {$b_data_directory}

--- a/src/frontend/translations.rs
+++ b/src/frontend/translations.rs
@@ -1,5 +1,24 @@
 mod messages {
     #![allow(clippy::all)]
+
+    use fluent_static::fluent_bundle::{FluentArgs, FluentValue};
+    // TODO: This is used inside the generated file and is a hack for
+    //  https://github.com/projectfluent/fluent-rs/issues/368
+    fn number<'a>(positional: &[FluentValue<'a>], named: &FluentArgs) -> FluentValue<'a> {
+        let Some(FluentValue::Number(n)) = positional.first() else {
+            return FluentValue::Error;
+        };
+
+        let mut n = n.clone();
+        n.options.merge(named);
+        if let Some(maximum_fraction_digits) = n.options.maximum_fraction_digits {
+            let multiplier = 10f64.powf(maximum_fraction_digits as f64);
+            n.value = (n.value * multiplier).round() / multiplier;
+        }
+
+        FluentValue::Number(n)
+    }
+
     pub use messages::*;
     include!(concat!(env!("OUT_DIR"), "/l10n.rs"));
 }


### PR DESCRIPTION
Follow-up to https://github.com/autonomys/space-acres/pull/258.

Had to prefix placeables/variables with `a_` and such for function argument order to be predictable due to https://github.com/zaytsev/fluent-static/issues/9 (which kind of makes sense, but was still surprising).