### PR TITLE
Capture panics on Windows as tracing events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11785,6 +11785,7 @@ dependencies = [
  "thread-priority",
  "tokio",
  "tracing",
+ "tracing-panic",
  "tracing-subscriber",
  "tracker",
  "winres",
@@ -12892,6 +12893,16 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-panic"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bf1298a179837099f9309243af3b554e840f7f67f65e9f55294913299bd4cc5"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ tracker = "0.2.2"
 
 [target.'cfg(windows)'.dependencies]
 native-dialog = "0.7.0"
+tracing-panic = "0.1.2"
 
 [build-dependencies]
 fluent-static-codegen = "0.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,8 @@ impl Cli {
                         .with(layer.with_filter(filter))
                         .init();
                 }
+                #[cfg(windows)]
+                std::panic::set_hook(Box::new(tracing_panic::panic_hook));
             } else {
                 tracing_subscriber::registry()
                     .with(layer.with_filter(filter))


### PR DESCRIPTION
This will greatly help with debugging on Windows where stderr is not possible to capture with `#![windows_subsystem = "windows"]`

Fixes https://github.com/autonomys/space-acres/issues/188