### PR TITLE
Remove .cargo/config and +aes feature on x86-64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[target.'cfg(target_arch = "x86_64")']
-# Require AES-NI on x86-64 by default
-rustflags = ["-C", "target-feature=+aes"]


### PR DESCRIPTION
Same reasoning as in https://github.com/autonomys/subspace/pull/2964