### PR TITLE
Show minimized app when attempting to open another instance

### DIFF
--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -620,6 +620,14 @@ impl AsyncComponent for App {
             }
         }
 
+        relm4::main_application().connect_activate({
+            let root = root.clone();
+
+            move |_application| {
+                root.present();
+            }
+        });
+
         if model.tray_icon.is_some() {
             root.set_hide_on_close(true);
         }


### PR DESCRIPTION
Basically if Space Acres was minimized to tray and user tried to open Space Acres nothing was happening (because only one instance of Space Acres can be running at a time). With this change original app will be un-minimized when this happens, which is most likely what user expects.