### PR TITLE
Roll back gvsbuild to older stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,8 @@ jobs:
 
       - name: Install GTK4 (Windows)
         run: |
-          pipx install gvsbuild
+          # TODO: Remove constraint once https://github.com/wingtk/gvsbuild/issues/1436 is fixed
+          pipx install gvsbuild==2024.8.1
           gvsbuild build gtk4 librsvg
         if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,8 @@ jobs:
 
       - name: Install GTK4 (Windows)
         run: |
-          pipx install gvsbuild
+          # TODO: Remove constraint once https://github.com/wingtk/gvsbuild/issues/1436 is fixed
+          pipx install gvsbuild==2024.8.1
           gvsbuild build gtk4 librsvg
         if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 
@@ -182,7 +183,8 @@ jobs:
 
       - name: Install GTK4 (Windows)
         run: |
-          pipx install gvsbuild
+          # TODO: Remove constraint once https://github.com/wingtk/gvsbuild/issues/1436 is fixed
+          pipx install gvsbuild==2024.8.1
           gvsbuild build gtk4 librsvg
         if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 


### PR DESCRIPTION
Caused by https://github.com/wingtk/gvsbuild/issues/1436