### PR TITLE
Update OS requirements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             suffix: ubuntu-x86_64-skylake-${{ github.ref_name }}
             modern-rustflags: "-C target-cpu=skylake"
             rustflags: "-C target-cpu=x86-64-v2"
           # TODO: Package for more Linux distributions/packaging formats/architectures and macOS
-          #- os: ubuntu-22.04
+          #- os: ubuntu-24.04
           #  target: aarch64-unknown-linux-gnu
           #  suffix: ubuntu-aarch64-${{ github.ref_name }}
           #  rustflags: "-C linker=aarch64-linux-gnu-gcc"
@@ -103,13 +103,17 @@ jobs:
         run: brew install libtool
         if: runner.os == 'macOS'
 
-      - name: CUDA toolchain
-        uses: Jimver/cuda-toolkit@9b295696791d75d658d8de64c4a85097ad8abeaf # v0.2.16
+      - name: CUDA toolchain (Windows)
+        uses: Jimver/cuda-toolkit@dc581bec6470cf161025608f13d71b3c00c2c0b7 # v0.2.17
         with:
           cuda: '12.4.1'
           method: network
           sub-packages: '["nvcc", "cudart"]'
-        if: runner.os == 'Linux' || runner.os == 'Windows'
+        if: runner.os == 'Windows'
+
+      - name: CUDA toolchain (Ubuntu)
+        run: sudo apt-get install -y --no-install-recommends nvidia-cuda-toolkit
+        if: runner.os == 'Linux'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -143,7 +147,9 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Build app (Linux, modern, CUDA)
+        # CXX for CUDA
         env:
+          CXX: g++-12
           RUSTFLAGS: ${{ matrix.build.modern-rustflags }}
         run: |
           cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --features cuda
@@ -165,7 +171,9 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Build app (Linux or Windows, normal, CUDA)
+        # CXX for CUDA
         env:
+          CXX: g++-12
           RUSTFLAGS: ${{ matrix.build.rustflags }}
         run: cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --features cuda
         if: runner.os == 'Linux' || runner.os == 'Windows'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   cargo-fmt:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
           - macos-14
           - windows-2022
 
@@ -121,13 +121,17 @@ jobs:
         run: brew install libtool
         if: runner.os == 'macOS'
 
-      - name: CUDA toolchain
-        uses: Jimver/cuda-toolkit@9b295696791d75d658d8de64c4a85097ad8abeaf # v0.2.16
+      - name: CUDA toolchain (Windows)
+        uses: Jimver/cuda-toolkit@dc581bec6470cf161025608f13d71b3c00c2c0b7 # v0.2.17
         with:
           cuda: '12.4.1'
           method: network
           sub-packages: '["nvcc", "cudart"]'
-        if: runner.os == 'Linux' || runner.os == 'Windows'
+        if: runner.os == 'Windows'
+
+      - name: CUDA toolchain (Ubuntu)
+        run: sudo apt-get install -y --no-install-recommends nvidia-cuda-toolkit
+        if: runner.os == 'Linux'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -162,13 +166,20 @@ jobs:
 
       - name: cargo clippy
         run: cargo -Zgitoxide -Zgit clippy --locked --all-targets --features cuda -- -D warnings
-        if: runner.os == 'Linux' || runner.os == 'Windows'
+        if: runner.os == 'Windows'
+
+      - name: cargo clippy
+        # CXX for CUDA
+        env:
+          CXX: g++-12
+        run: cargo -Zgitoxide -Zgit clippy --locked --all-targets --features cuda -- -D warnings
+        if: runner.os == 'Linux'
 
   cargo-test:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
           - macos-14
           - windows-2022
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -52,8 +52,8 @@ this application may sometimes work fine and sometimes have a hard time syncing 
 
 For Windows go to [the latest release](https://github.com/autonomys/space-acres/releases/latest) and download attached
 file with `.msi` extension. It is not digitally signed, so you'll have to agree to accept the risk when downloading and
-installing it for now. Note that while things might work on other versions of Windows, **only Windows 10 and 11** with
-latest updates supported.
+installing it for now. Note that while things might work on other versions of Windows, **only Windows 11** with
+latest updates is supported.
 
 ### Dependencies
 
@@ -72,7 +72,7 @@ Currently, there are two ways to get Space Acres on Linux:
 
 ### Ubuntu
 
-For **Ubuntu 22.04 or newer** (older versions not supported) go
+For **Ubuntu 24.04 or newer** (older versions not supported) go
 to [the latest release](https://github.com/autonomys/space-acres/releases/latest) and download attached
 file with `.deb` extension for your architecture (most likely `amd64`).
 


### PR DESCRIPTION
Windows 10 and Ubuntu 22.04/22.10/23.04/23.10 are no longer officially supported. They may still work with official or unofficial builds, but nothing is guaranteed anymore.