### PR TITLE
Switch to relm4-icons upstream pre-release and improve error display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9261,16 +9261,18 @@ checksum = "1d3b924557df1cddc687b60b313c4b76620fdbf0e463afa4b29f67193ccf37f9"
 
 [[package]]
 name = "relm4-icons"
-version = "0.9.0"
-source = "git+https://github.com/Relm4/icons?rev=74dc5af44e0dc6bb397cbb6c32d6d57661a26601#74dc5af44e0dc6bb397cbb6c32d6d57661a26601"
+version = "0.10.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4b1a664ccea4662eea207c48191d403b46ea512eb385b8f7f571a1a45a0dda"
 dependencies = [
  "gtk4",
 ]
 
 [[package]]
 name = "relm4-icons-build"
-version = "0.1.0"
-source = "git+https://github.com/Relm4/icons?rev=74dc5af44e0dc6bb397cbb6c32d6d57661a26601#74dc5af44e0dc6bb397cbb6c32d6d57661a26601"
+version = "0.10.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a085f4290a4820566b547621859f0acb388cb493cf10f0e4c7293a471fc695e"
 dependencies = [
  "gvdb",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,7 @@ parity-scale-codec = "3.6.12"
 parking_lot = "0.12.3"
 relm4 = "0.9.1"
 relm4-components = { version = "0.9.1", default-features = false }
-# TODO: Switch to upstream release 0.10.0+ that includes https://github.com/Relm4/icons/pull/19
-relm4-icons = { version = "0.9.0", git = "https://github.com/Relm4/icons", rev = "74dc5af44e0dc6bb397cbb6c32d6d57661a26601" }
+relm4-icons = "0.10.0-beta.0"
 reqwest = { version = "0.12.8", default-features = false, features = ["json", "rustls-tls"] }
 sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42", default-features = false }
 sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42", default-features = false }
@@ -126,8 +125,7 @@ ksni = "0.2.2"
 
 [build-dependencies]
 fluent-static-codegen = "0.5.0"
-# TODO: Switch to upstream release, right now it is unreleased
-relm4-icons-build = { version = "0.1.0", git = "https://github.com/Relm4/icons", rev = "74dc5af44e0dc6bb397cbb6c32d6d57661a26601" }
+relm4-icons-build = "0.10.0-beta.0"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.12"

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -409,6 +409,8 @@ impl AsyncComponent for App {
                             gtk::Label {
                                 #[track = "model.changed_current_view()"]
                                 set_label: T.stopped_message_with_error(error.to_string()).as_str(),
+                                set_selectable: true,
+                                set_wrap: true,
                             },
 
                             gtk::Box {
@@ -439,6 +441,8 @@ impl AsyncComponent for App {
                             gtk::Label {
                                 #[track = "model.changed_current_view()"]
                                 set_label: &T.error_message(error.to_string()).as_str(),
+                                set_selectable: true,
+                                set_wrap: true,
                             },
 
                             gtk::Box {


### PR DESCRIPTION
Errors no longer cause window becoming huge and error message can be copied