### PR TITLE
Sign both outer bundle and inner installer on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,24 +321,43 @@ jobs:
 
           # TODO: Ideally something like this would have worked and we wouldn't need to hardcode stuff in `space-acres.wxs`: https://github.com/volks73/cargo-wix/issues/271
           # & "C:\Program Files (x86)\WiX Toolset v3.11\bin\heat.exe" dir target\wix\gtk4 -gg -sfrag -template:fragment -out target\wix\gtk4.wxs -cg GTK -dr GTK
-          
+
           cargo wix --target ${{ matrix.build.target }} --profile production --no-build --nocapture
-          # Create bundle with Microsoft Visual C++ Redistributable in it
-          Remove-Item target\wix\space-acres.wixobj -Confirm:$false
-          cargo wix --profile release --no-build --nocapture --include res\windows\wix\bundle.wxs -C -ext -C WixBalExtension
 
           Remove-Item target\wix\gtk4 -Recurse -Confirm:$false -ErrorAction SilentlyContinue
         if: runner.os == 'Windows'
 
-      - name: Sign Application (Windows)
+      - name: Sign installer (Windows)
         run: |
           $ErrorActionPreference = "Stop"
-          
+
           dotnet tool install --global AzureSignTool
 
-          (Get-ChildItem -Path target\wix -Include space-acres-*.exe -Recurse) | ForEach-Object {
+          (Get-ChildItem -Path target\wix -Include space-acres-*.msi) | ForEach-Object {
             Write("Signing $($_)");
-          
+
+            AzureSignTool sign --azure-key-vault-url "${{ secrets.AZURE_KEY_VAULT_URI }}" --azure-key-vault-client-id "${{ secrets.AZURE_CLIENT_ID }}" --azure-key-vault-client-secret "${{ secrets.AZURE_CLIENT_SECRET }}" --azure-key-vault-tenant-id "${{ secrets.AZURE_TENANT_ID }}" --azure-key-vault-certificate "${{ secrets.AZURE_CERT_NAME }}" --file-digest sha512 --timestamp-rfc3161 http://timestamp.digicert.com -v $($_);
+          }
+        # Allow code signing to fail on non-release builds and in non-autonomys repos (forks)
+        continue-on-error: ${{ github.repository_owner != 'autonomys' || github.event_name != 'push' || github.ref_type != 'tag' }}
+        if: runner.os == 'Windows'
+
+      - name: Create bundle (Windows)
+        run: |
+          # Create a bundle with Microsoft Visual C++ Redistributable in it
+          Remove-Item target\wix\space-acres.wixobj -Confirm:$false
+          cargo wix --profile release --no-build --nocapture --include res\windows\wix\bundle.wxs -C -ext -C WixBalExtension
+        if: runner.os == 'Windows'
+
+      - name: Sign bundle (Windows)
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          dotnet tool install --global AzureSignTool
+
+          (Get-ChildItem -Path target\wix -Include space-acres-*.exe) | ForEach-Object {
+            Write("Signing $($_)");
+
             AzureSignTool sign --azure-key-vault-url "${{ secrets.AZURE_KEY_VAULT_URI }}" --azure-key-vault-client-id "${{ secrets.AZURE_CLIENT_ID }}" --azure-key-vault-client-secret "${{ secrets.AZURE_CLIENT_SECRET }}" --azure-key-vault-tenant-id "${{ secrets.AZURE_TENANT_ID }}" --azure-key-vault-certificate "${{ secrets.AZURE_CERT_NAME }}" --file-digest sha512 --timestamp-rfc3161 http://timestamp.digicert.com -v $($_);
           }
         # Allow code signing to fail on non-release builds and in non-autonomys repos (forks)


### PR DESCRIPTION
Should fix installation on Windows after https://github.com/autonomys/space-acres/pull/324 due to installation of unsigned .msi being not supported from signed .exe and resulting in errors like these:
```
[35E8:365C][2024-11-09T22:31:08]e312: Failed to extract payloads from container: WixAttachedContainer to working path: C:\Windows\Temp{2659BD1A-AD4F-41E3-97FB-DD05575D9E94}\2921D55D9706507495DD58643508D385E5DF6629, error: 0x80070001.
[35E8:35EC][2024-11-09T22:31:08]e000: Error 0x80070001: Failed while caching, aborting execution.
[3638:363C][2024-11-09T22:31:08]i372: Session end, registration key: SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall{ffa4f922-d8d4-4015-a8f7-78572989ff15}, resume: None, restart: None, disable resume: No
[3638:363C][2024-11-09T22:31:08]i330: Removed bundle dependency provider: {ffa4f922-d8d4-4015-a8f7-78572989ff15}
[3638:363C][2024-11-09T22:31:08]i352: Removing cached bundle: {ffa4f922-d8d4-4015-a8f7-78572989ff15}, from path: C:\ProgramData\Package Cache{ffa4f922-d8d4-4015-a8f7-78572989ff15}\
[3638:363C][2024-11-09T22:31:08]i371: Updating session, registration key: SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall{ffa4f922-d8d4-4015-a8f7-78572989ff15}, resume: None, restart initiated: No, disable resume: No
[35E8:35EC][2024-11-09T22:31:08]i399: Apply complete, result: 0x80070001, restart: None, ba requested restart:  No
```