### PR TITLE
Change the location of an icon file in deb package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ assets = [
     ["res/linux/space-acres-autostart.desktop", "/etc/xdg/autostart/space-acres.desktop", "644"],
     ["target/release/space-acres", "/usr/bin/space-acres", "755"],
     ["res/linux/space-acres.desktop", "/usr/share/applications/space-acres.desktop", "644"],
-    ["res/linux/space-acres.png", "/usr/share/pixmaps/space-acres.png", "644"],
+    ["res/linux/space-acres.png", "/usr/share/icons/hicolor/256x256/apps/space-acres.png", "644"],
 ]
 
 [package.metadata.deb.variants.modern]


### PR DESCRIPTION
This appears to be more correct and allows to render correct icon in the dash in GNOME desktop