### PR TITLE
Improve crash handling on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5064,12 +5064,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12145,7 +12139,6 @@ dependencies = [
  "subspace-rpc-primitives",
  "subspace-runtime-primitives",
  "subspace-service",
- "supports-color",
  "sys-locale",
  "tempfile",
  "thiserror 2.0.1",
@@ -12796,15 +12789,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8775305acf21c96926c900ad056abeef436701108518cf890020387236ac5a77"
-dependencies = [
- "is_ci",
-]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ subspace-proof-of-space-gpu = { git = "https://github.com/subspace/subspace", re
 subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "ac3d5e5fad8007a15e7aff3790d4e7ceb3ad7a0f" }
 subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "ac3d5e5fad8007a15e7aff3790d4e7ceb3ad7a0f" }
 subspace-service = { git = "https://github.com/subspace/subspace", rev = "ac3d5e5fad8007a15e7aff3790d4e7ceb3ad7a0f" }
-supports-color = "3.0.1"
 sys-locale = "0.3.1"
 tempfile = "3.13.0"
 thiserror = "2.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -512,6 +512,12 @@ impl Cli {
                     }
                     AppStatusCode::Unknown(status_code) => {
                         error!(%status_code, "Application exited with unexpected status code");
+
+                        if last_start.elapsed() >= MIN_RUNTIME_DURATION_FOR_AUTORESTART {
+                            self.after_crash = true;
+                            continue;
+                        }
+
                         process::exit(status_code);
                     }
                 },


### PR DESCRIPTION
In https://github.com/autonomys/space-acres/issues/361 it was discovered that on macOS segfault causes process to exit with code `11`, while on Linux it exits with `SIGSEGV`.

This change will support exit with unexpected status codes (like `11` on macOS) as a reason for application restart like like termination with a signal on Linux.

The first commit here improves logs handling by capturing supervisor logs in log file, which were missing previously, this will help with debugging in the future by providing details about why process exited.