### PR TITLE
Small fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12069,7 +12069,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "space-acres"
 description = "Space Acres is an opinionated GUI application for farming on Autonomys Network"
 license = "0BSD"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/autonomys/space-acres"
 edition = "2021"

--- a/src/frontend/running.rs
+++ b/src/frontend/running.rs
@@ -529,7 +529,7 @@ impl RunningView {
         } else {
             self.farmer_state.local_space_pledged * u64::from(self.farmer_state.sectors_plotted)
                 / u64::from(self.farmer_state.sectors_total)
-                * u64::from(self.farmer_state.cache_percentage.get())
+                * (100 - u64::from(self.farmer_state.cache_percentage.get()))
                 / 100
         };
 

--- a/src/frontend/running/node.rs
+++ b/src/frontend/running/node.rs
@@ -131,7 +131,7 @@ impl Component for NodeView {
                     set_css_classes: &[
                         "flat",
                         match model.connected_peers {
-                            ALL_PEERS => "success-label",
+                            ALMOST_ALL_PEERS.. => "success-label",
                             ..OUT_PEERS => "error-label",
                             _ => "warning-label",
                         },
@@ -163,7 +163,7 @@ impl Component for NodeView {
                                     0 => icon_names::STRENGTH_BARS_6,
                                     ..OUT_PEERS => icon_names::STRENGTH_BARS_5,
                                     OUT_PEERS => icon_names::STRENGTH_BARS_4,
-                                    ..=ALMOST_ALL_PEERS => icon_names::STRENGTH_BARS_3,
+                                    ..ALMOST_ALL_PEERS => icon_names::STRENGTH_BARS_3,
                                     _ => icon_names::STRENGTH_NARS_2,
                                 }),
                         },


### PR DESCRIPTION
This fixes reward ETA calculation (it was using cache size instead of space pledged minus cache size for estimation and was 99x off as the result :grimacing: ).
Also network indicator gets green before reaching 40 peers since even a few less peers is perfectly fine.