### PR TITLE
Update substrate and subspace deps, rust toolchain and migrate to 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,14 +48,11 @@ dependencies = [
  "ahash 0.8.11",
  "base64 0.22.1",
  "bitflags 2.6.0",
- "brotli",
  "bytes",
  "bytestring",
  "derive_more 0.99.18",
  "encoding_rs",
- "flate2",
  "futures-core",
- "h2 0.3.26",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -65,13 +62,12 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
- "zstd 0.13.2",
 ]
 
 [[package]]
@@ -81,7 +77,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -93,7 +89,6 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "http 0.2.12",
- "regex",
  "regex-lite",
  "serde",
  "tracing",
@@ -121,7 +116,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tracing",
 ]
@@ -166,7 +161,6 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie",
  "derive_more 0.99.18",
  "encoding_rs",
  "futures-core",
@@ -178,13 +172,12 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project-lite",
- "regex",
  "regex-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.7",
+ "socket2",
  "time",
  "url",
 ]
@@ -198,7 +191,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -283,7 +276,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -295,7 +288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -321,21 +314,6 @@ name = "aligned-vec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
 
 [[package]]
 name = "allocator-api2"
@@ -433,7 +411,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -456,7 +434,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -585,7 +563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -614,12 +592,12 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive 0.4.0",
- "asn1-rs-impl 0.1.0",
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
@@ -630,30 +608,18 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
- "asn1-rs-derive 0.5.1",
- "asn1-rs-impl 0.2.0",
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.65",
+ "thiserror 2.0.12",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -664,19 +630,20 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
  "synstructure 0.13.1",
 ]
 
 [[package]]
-name = "asn1-rs-impl"
-version = "0.1.0"
+name = "asn1-rs-derive"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.102",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -687,7 +654,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -815,7 +782,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -844,13 +811,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -989,10 +956,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom",
+ "getrandom 0.2.15",
  "instant",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -1052,6 +1019,16 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "binary-merkle-tree"
+version = "16.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+]
 
 [[package]]
 name = "bincode"
@@ -1162,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.4"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1254,33 +1231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
-name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-
-[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,9 +1253,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byte-tools"
@@ -1333,9 +1283,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -1531,15 +1481,14 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
 dependencies = [
  "core2",
  "multibase",
- "multihash 0.18.1",
- "serde",
- "unsigned-varint 0.7.2",
+ "multihash 0.19.1",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -1633,7 +1582,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1761,9 +1710,29 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1791,17 +1760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "cookie"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
 ]
 
 [[package]]
@@ -1909,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -2032,7 +1990,7 @@ checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "domain-block-preprocessor",
  "fp-account",
@@ -2053,7 +2011,7 @@ dependencies = [
  "sp-messenger",
  "sp-runtime",
  "subspace-runtime-primitives",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2104,7 +2062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -2116,7 +2074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2182,7 +2140,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2258,11 +2216,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.2.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs 0.5.2",
+ "asn1-rs 0.6.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -2272,11 +2230,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.6.2",
+ "asn1-rs 0.7.1",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -2312,7 +2270,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2325,7 +2283,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2346,7 +2304,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
  "unicode-xid",
 ]
 
@@ -2481,7 +2439,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2492,18 +2450,18 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "docify"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2f138ad521dc4a2ced1a4576148a6a610b4c5923933b062a263130a6802ce"
+checksum = "a772b62b1837c8f060432ddcc10b17aae1453ef17617a99bc07789252d2a5896"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a081e51fb188742f5a7a1164ad752121abcb22874b21e2c3b0dd040c515fdad"
+checksum = "60e6be249b0a462a14784a99b19bf35a667bb5e09de611738bb7362fa4c95ff7"
 dependencies = [
  "common-path",
  "derive-syn-parse",
@@ -2511,31 +2469,53 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.102",
  "termcolor",
  "toml 0.8.19",
  "walkdir",
 ]
 
 [[package]]
+name = "domain-block-builder"
+version = "0.1.0"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
+dependencies = [
+ "hash-db",
+ "hex-literal",
+ "parity-scale-codec",
+ "sc-chain-spec",
+ "sc-client-api",
+ "sc-executor",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-core",
+ "sp-domains",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "subspace-runtime-primitives",
+ "tracing",
+]
+
+[[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
  "parity-scale-codec",
  "sc-client-api",
  "sc-executor",
- "sc-executor-common",
  "sp-api",
  "sp-block-fees",
  "sp-blockchain",
  "sp-core",
  "sp-domain-sudo",
  "sp-domains",
+ "sp-evm-tracker",
  "sp-executive",
- "sp-externalities",
  "sp-inherents",
  "sp-messenger",
  "sp-mmr-primitives",
@@ -2553,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "fp-account",
  "frame-support",
@@ -2659,7 +2639,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -2676,7 +2656,7 @@ dependencies = [
  "ed25519",
  "hashbrown 0.14.5",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "zeroize",
 ]
@@ -2700,7 +2680,7 @@ dependencies = [
  "generic-array 0.14.7",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "serdect",
  "subtle 2.6.1",
@@ -2730,18 +2710,6 @@ checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
@@ -2749,7 +2717,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2769,7 +2737,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2790,7 +2758,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2884,10 +2852,10 @@ dependencies = [
  "blake2 0.10.6",
  "file-guard",
  "fs-err",
- "prettyplease 0.2.22",
+ "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2943,7 +2911,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -3028,7 +2996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3181,7 +3149,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3192,8 +3160,8 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fork-tree"
-version = "13.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "13.0.1"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3220,7 +3188,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/autonomys/frontier?rev=f80f9e2bad338f3bf3854b256b3c4edea23e5968#f80f9e2bad338f3bf3854b256b3c4edea23e5968"
+source = "git+https://github.com/autonomys/frontier?rev=986eb1ad6ec69c16d05d142b7e731b4b69e3b409#986eb1ad6ec69c16d05d142b7e731b4b69e3b409"
 dependencies = [
  "hex",
  "impl-serde",
@@ -3244,8 +3212,8 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "39.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3267,10 +3235,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-executive"
+version = "39.1.1"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
+dependencies = [
+ "aquamarine",
+ "frame-support",
+ "frame-system",
+ "frame-try-runtime",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-tracing",
+]
+
+[[package]]
 name = "frame-metadata"
-version = "16.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cf1549fba25a6fcac22785b61698317d958e96cac72a59102ea45b9ae64692"
+checksum = "daaf440c68eb2c3d88e5760fe8c7af3f9fee9181fab6c2f2c4e7cc48dcc40bb8"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -3280,11 +3266,12 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "39.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "aquamarine",
  "array-bytes",
+ "binary-merkle-tree",
  "bitflags 1.3.2",
  "docify",
  "environmental",
@@ -3314,6 +3301,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-tracing",
+ "sp-trie",
  "sp-weights",
  "static_assertions",
  "tt-call",
@@ -3321,8 +3309,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "30.0.3"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "31.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "Inflector",
  "cfg-expr 0.15.8",
@@ -3332,39 +3320,39 @@ dependencies = [
  "frame-support-procedural-tools",
  "itertools 0.11.0",
  "macro_magic",
- "proc-macro-warning 1.0.2",
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "13.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "13.0.1"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "frame-system"
-version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "39.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3382,13 +3370,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-system-benchmarking"
+version = "39.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "frame-system-rpc-runtime-api"
-version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "35.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "docify",
  "parity-scale-codec",
  "sp-api",
+]
+
+[[package]]
+name = "frame-try-runtime"
+version = "0.45.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3463,16 +3476,6 @@ dependencies = [
 
 [[package]]
 name = "futures-bounded"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b07bbbe7d7e78809544c6f718d875627addc73a7c3582447abc052cd3dc67e0"
-dependencies = [
- "futures-timer",
- "futures-util",
-]
-
-[[package]]
-name = "futures-bounded"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
@@ -3536,7 +3539,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3546,16 +3549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b460264b3593d68b16a7bc35f7bc226ddfebdf9a1c8db1ed95d5cc6b7168c826"
 dependencies = [
  "pin-project-lite",
-]
-
-[[package]]
-name = "futures-rustls"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd3cf68c183738046838e300353e4716c674dc5e56890de4826801a6622a28"
-dependencies = [
- "futures-io",
- "rustls 0.21.12",
 ]
 
 [[package]]
@@ -3580,17 +3573,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-ticker"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
-dependencies = [
- "futures",
- "futures-timer",
- "instant",
-]
 
 [[package]]
 name = "futures-timer"
@@ -3741,6 +3723,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.61.1",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3769,8 +3765,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3779,8 +3787,8 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3937,7 +3945,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3950,7 +3958,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4016,7 +4024,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "spinning_top",
 ]
@@ -4051,7 +4059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -4135,7 +4143,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4168,7 +4176,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4207,25 +4215,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.6.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
@@ -4236,7 +4225,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4377,12 +4366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
-name = "hexlit"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6e75c860d4216ac53f9ac88b25c99eaedba075b3a7b2ed31f2adc51a74fffd"
-
-[[package]]
 name = "hickory-proto"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4391,16 +4374,41 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner 0.6.1",
+ "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
  "idna 0.4.0",
  "ipnet",
  "once_cell",
- "rand",
- "socket2 0.5.7",
+ "rand 0.8.5",
+ "socket2",
  "thiserror 1.0.65",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 1.0.3",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.1",
+ "ring 0.17.8",
+ "thiserror 2.0.12",
  "tinyvec",
  "tokio",
  "tracing",
@@ -4415,15 +4423,36 @@ checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.24.1",
  "ipconfig",
  "lru-cache",
  "once_cell",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.65",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto 0.25.2",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "rand 0.9.1",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -4511,17 +4540,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -4539,7 +4557,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -4608,30 +4626,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.7",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
@@ -4639,9 +4633,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
+ "h2",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -4653,34 +4647,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.30",
- "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
+ "log",
  "rustls 0.23.14",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 0.26.6",
 ]
@@ -4695,10 +4675,10 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.4.1",
+ "http-body",
+ "hyper",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4728,26 +4708,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap 0.8.0",
+ "tinystr 0.8.1",
+ "writeable 0.6.1",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locid"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
+ "litemap 0.7.3",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
 ]
 
 [[package]]
-name = "idna"
-version = "0.2.3"
+name = "icu_normalizer"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr 0.8.1",
+ "writeable 0.6.1",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -4762,12 +4817,23 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -4801,18 +4867,20 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.14.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
+checksum = "76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93"
 dependencies = [
  "async-trait",
  "attohttpc 0.24.1",
  "bytes",
  "futures",
- "http 0.2.12",
- "hyper 0.14.30",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "log",
- "rand",
+ "rand 0.8.5",
  "tokio",
  "url",
  "xmltree",
@@ -4859,9 +4927,9 @@ checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
 
 [[package]]
 name = "impl-codec"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4873,23 +4941,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
 
 [[package]]
-name = "impl-serde"
-version = "0.4.0"
+name = "impl-num-traits"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+checksum = "803d15461ab0dcc56706adf266158acbc44ccf719bf7d0af30705f58b90a4b8c"
+dependencies = [
+ "integer-sqrt",
+ "num-traits",
+ "uint 0.10.0",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4924,9 +5003,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.0",
@@ -4977,7 +5056,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5021,7 +5100,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.7",
+ "socket2",
  "widestring",
  "windows-sys 0.48.0",
  "winreg 0.50.0",
@@ -5184,7 +5263,7 @@ dependencies = [
  "soketto",
  "thiserror 1.0.65",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "url",
@@ -5201,12 +5280,12 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rustc-hash 2.0.0",
  "serde",
  "serde_json",
@@ -5226,7 +5305,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5237,9 +5316,9 @@ checksum = "e30110d0f2d7866c8cc6c86483bdab2eb9f4d2f0e20db55518b2bca84651ba8e"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -5410,9 +5489,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -5453,181 +5532,90 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94495eb319a85b70a68b85e2389a95bb3555c71c49025b78c691a854a7e6464"
+version = "0.54.2"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "bytes",
  "either",
  "futures",
  "futures-timer",
- "getrandom",
- "instant",
- "libp2p-allow-block-list 0.2.0",
- "libp2p-connection-limits 0.2.1",
- "libp2p-core 0.40.1",
- "libp2p-dns 0.40.1",
- "libp2p-identify 0.43.1",
- "libp2p-identity",
- "libp2p-kad 0.44.6",
- "libp2p-mdns 0.44.0",
- "libp2p-metrics 0.13.1",
- "libp2p-noise 0.43.2",
- "libp2p-ping 0.43.1",
- "libp2p-quic 0.9.3",
- "libp2p-request-response 0.25.3",
- "libp2p-swarm 0.43.7",
- "libp2p-tcp 0.40.1",
- "libp2p-upnp 0.1.1",
- "libp2p-wasm-ext",
- "libp2p-websocket",
- "libp2p-yamux 0.44.1",
- "multiaddr 0.18.2",
- "pin-project",
- "rw-stream-sink 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.65",
-]
-
-[[package]]
-name = "libp2p"
-version = "0.54.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom",
- "libp2p-allow-block-list 0.4.0",
+ "getrandom 0.2.15",
+ "libp2p-allow-block-list",
  "libp2p-autonat",
- "libp2p-connection-limits 0.4.0",
- "libp2p-core 0.42.0",
- "libp2p-dns 0.42.0",
+ "libp2p-connection-limits",
+ "libp2p-core",
+ "libp2p-dns",
  "libp2p-gossipsub",
- "libp2p-identify 0.45.0",
+ "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.46.1",
- "libp2p-mdns 0.46.0",
- "libp2p-metrics 0.15.0",
- "libp2p-noise 0.45.0",
- "libp2p-ping 0.45.0",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-noise",
+ "libp2p-ping",
  "libp2p-plaintext",
- "libp2p-quic 0.11.1",
- "libp2p-request-response 0.27.0",
- "libp2p-swarm 0.45.1",
- "libp2p-tcp 0.42.0",
- "libp2p-upnp 0.3.0",
- "libp2p-yamux 0.46.0",
+ "libp2p-quic",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-upnp",
+ "libp2p-websocket",
+ "libp2p-yamux",
  "multiaddr 0.18.2",
  "pin-project",
- "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d)",
- "thiserror 1.0.65",
+ "rw-stream-sink",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b46558c5c0bf99d3e2a1a38fd54ff5476ca66dd1737b12466a1824dd219311"
+version = "0.4.2"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
- "libp2p-core 0.40.1",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.43.7",
- "void",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
-version = "0.4.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
-dependencies = [
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "void",
+ "libp2p-swarm",
 ]
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.13.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+version = "0.13.1"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",
  "bytes",
  "either",
  "futures",
- "futures-bounded 0.2.4",
+ "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-request-response 0.27.0",
- "libp2p-swarm 0.45.1",
+ "libp2p-request-response",
+ "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1",
- "rand",
- "rand_core",
- "thiserror 1.0.65",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "thiserror 2.0.12",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5107ad45cb20b2f6c3628c7b6014b996fcb13a88053f4569c872c6e30abf58"
+version = "0.4.1"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
- "libp2p-core 0.40.1",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.43.7",
- "void",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
-version = "0.4.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
-dependencies = [
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "void",
+ "libp2p-swarm",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd44289ab25e4c9230d9246c475a22241e301b23e8f4061d3bdef304a1a99713"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-identity",
- "log",
- "multiaddr 0.18.2",
- "multihash 0.19.1",
- "multistream-select 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell",
- "parking_lot 0.12.3",
- "pin-project",
- "quick-protobuf",
- "rand",
- "rw-stream-sink 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec",
- "thiserror 1.0.65",
- "unsigned-varint 0.7.2",
- "void",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+version = "0.42.1"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "either",
  "fnv",
@@ -5636,47 +5624,30 @@ dependencies = [
  "libp2p-identity",
  "multiaddr 0.18.2",
  "multihash 0.19.1",
- "multistream-select 0.13.0 (git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d)",
+ "multistream-select",
  "once_cell",
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
- "rand",
- "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d)",
+ "rand 0.8.5",
+ "rw-stream-sink",
  "serde",
  "smallvec",
- "thiserror 1.0.65",
+ "thiserror 2.0.12",
  "tracing",
  "unsigned-varint 0.8.0",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a18db73084b4da2871438f6239fef35190b05023de7656e877c18a00541a3b"
-dependencies = [
- "async-trait",
- "futures",
- "libp2p-core 0.40.1",
- "libp2p-identity",
- "log",
- "parking_lot 0.12.3",
- "smallvec",
- "trust-dns-resolver",
-]
-
-[[package]]
-name = "libp2p-dns"
 version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "async-trait",
  "futures",
- "hickory-resolver",
- "libp2p-core 0.42.0",
+ "hickory-resolver 0.24.1",
+ "libp2p-core",
  "libp2p-identity",
  "parking_lot 0.12.3",
  "smallvec",
@@ -5685,9 +5656,10 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.47.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+version = "0.48.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
+ "async-channel 2.3.1",
  "asynchronous-codec 0.7.0",
  "base64 0.22.1",
  "byteorder",
@@ -5695,122 +5667,67 @@ dependencies = [
  "either",
  "fnv",
  "futures",
- "futures-ticker",
- "getrandom",
+ "futures-timer",
+ "getrandom 0.2.15",
  "hex_fmt",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "prometheus-client 0.22.3",
+ "libp2p-swarm",
+ "prometheus-client",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1",
- "rand",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
  "regex",
  "serde",
  "sha2 0.10.8",
  "smallvec",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a96638a0a176bec0a4bcaebc1afa8cf909b114477209d7456ade52c61cd9cd"
-dependencies = [
- "asynchronous-codec 0.6.2",
- "either",
- "futures",
- "futures-bounded 0.1.0",
- "futures-timer",
- "libp2p-core 0.40.1",
- "libp2p-identity",
- "libp2p-swarm 0.43.7",
- "log",
- "lru",
- "quick-protobuf",
- "quick-protobuf-codec 0.2.0",
- "smallvec",
- "thiserror 1.0.65",
- "void",
-]
-
-[[package]]
-name = "libp2p-identify"
-version = "0.45.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+version = "0.46.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
  "futures",
- "futures-bounded 0.2.4",
+ "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "lru",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1",
+ "quick-protobuf-codec",
  "smallvec",
- "thiserror 1.0.65",
+ "thiserror 2.0.12",
  "tracing",
- "void",
 ]
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cca1eb2bc1fd29f099f3daaab7effd01e1a54b7c577d0ed082521034d912e8"
+version = "0.2.10"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
- "bs58 0.5.1",
+ "bs58",
  "ed25519-dalek",
  "hkdf",
  "multihash 0.19.1",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
- "thiserror 1.0.65",
+ "thiserror 2.0.12",
  "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-kad"
-version = "0.44.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ea178dabba6dde6ffc260a8e0452ccdc8f79becf544946692fff9d412fc29d"
-dependencies = [
- "arrayvec",
- "asynchronous-codec 0.6.2",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.40.1",
- "libp2p-identity",
- "libp2p-swarm 0.43.7",
- "log",
- "quick-protobuf",
- "quick-protobuf-codec 0.2.0",
- "rand",
- "sha2 0.10.8",
- "smallvec",
- "thiserror 1.0.65",
- "uint 0.9.5",
- "unsigned-varint 0.7.2",
- "void",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.46.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+version = "0.47.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "arrayvec",
  "asynchronous-codec 0.7.0",
@@ -5818,145 +5735,80 @@ dependencies = [
  "either",
  "fnv",
  "futures",
- "futures-bounded 0.2.4",
+ "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1",
- "rand",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
  "smallvec",
- "thiserror 1.0.65",
+ "thiserror 2.0.12",
  "tracing",
  "uint 0.9.5",
- "void",
  "web-time",
-]
-
-[[package]]
-name = "libp2p-mdns"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a2567c305232f5ef54185e9604579a894fd0674819402bb0ac0246da82f52a"
-dependencies = [
- "data-encoding",
- "futures",
- "if-watch",
- "libp2p-core 0.40.1",
- "libp2p-identity",
- "libp2p-swarm 0.43.7",
- "log",
- "rand",
- "smallvec",
- "socket2 0.5.7",
- "tokio",
- "trust-dns-proto 0.22.0",
- "void",
 ]
 
 [[package]]
 name = "libp2p-mdns"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "data-encoding",
  "futures",
- "hickory-proto",
+ "hickory-proto 0.24.1",
  "if-watch",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "rand",
+ "libp2p-swarm",
+ "rand 0.8.5",
  "smallvec",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-metrics"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239ba7d28f8d0b5d77760dc6619c05c7e88e74ec8fbbe97f856f20a56745e620"
-dependencies = [
- "instant",
- "libp2p-core 0.40.1",
- "libp2p-identify 0.43.1",
- "libp2p-identity",
- "libp2p-kad 0.44.6",
- "libp2p-ping 0.43.1",
- "libp2p-swarm 0.43.7",
- "once_cell",
- "prometheus-client 0.21.2",
 ]
 
 [[package]]
 name = "libp2p-metrics"
 version = "0.15.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "futures",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-gossipsub",
- "libp2p-identify 0.45.0",
+ "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.46.1",
- "libp2p-ping 0.45.0",
- "libp2p-swarm 0.45.1",
+ "libp2p-kad",
+ "libp2p-ping",
+ "libp2p-swarm",
  "pin-project",
- "prometheus-client 0.22.3",
+ "prometheus-client",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eeec39ad3ad0677551907dd304b2f13f17208ccebe333bef194076cd2e8921"
-dependencies = [
- "bytes",
- "curve25519-dalek",
- "futures",
- "libp2p-core 0.40.1",
- "libp2p-identity",
- "log",
- "multiaddr 0.18.2",
- "multihash 0.19.1",
- "once_cell",
- "quick-protobuf",
- "rand",
- "sha2 0.10.8",
- "snow",
- "static_assertions",
- "thiserror 1.0.65",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "libp2p-noise"
 version = "0.45.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
  "curve25519-dalek",
  "futures",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "multiaddr 0.18.2",
  "multihash 0.19.1",
  "once_cell",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "snow",
  "static_assertions",
- "thiserror 1.0.65",
+ "thiserror 2.0.12",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -5964,369 +5816,189 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e702d75cd0827dfa15f8fd92d15b9932abe38d10d21f47c50438c71dd1b5dae3"
+version = "0.45.1"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "either",
  "futures",
  "futures-timer",
- "instant",
- "libp2p-core 0.40.1",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.43.7",
- "log",
- "rand",
- "void",
-]
-
-[[package]]
-name = "libp2p-ping"
-version = "0.45.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
-dependencies = [
- "either",
- "futures",
- "futures-timer",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "rand",
+ "libp2p-swarm",
+ "rand 0.8.5",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-plaintext"
 version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
  "futures",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1",
+ "quick-protobuf-codec",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-quic"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130d451d83f21b81eb7b35b360bc7972aeafb15177784adc56528db082e6b927"
+version = "0.11.2"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.40.1",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-tls 0.2.1",
- "log",
+ "libp2p-tls",
  "parking_lot 0.12.3",
- "quinn 0.10.2",
- "rand",
- "ring 0.16.20",
- "rustls 0.21.12",
- "socket2 0.5.7",
- "thiserror 1.0.65",
- "tokio",
-]
-
-[[package]]
-name = "libp2p-quic"
-version = "0.11.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
-dependencies = [
- "bytes",
- "futures",
- "futures-timer",
- "if-watch",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-tls 0.5.0",
- "parking_lot 0.12.3",
- "quinn 0.11.5",
- "rand",
+ "quinn",
+ "rand 0.8.5",
  "ring 0.17.8",
  "rustls 0.23.14",
- "socket2 0.5.7",
- "thiserror 1.0.65",
+ "socket2",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e3b4d67870478db72bac87bfc260ee6641d0734e0e3e275798f089c3fecfd4"
+version = "0.28.0"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "async-trait",
  "futures",
- "instant",
- "libp2p-core 0.40.1",
- "libp2p-identity",
- "libp2p-swarm 0.43.7",
- "log",
- "rand",
- "smallvec",
- "void",
-]
-
-[[package]]
-name = "libp2p-request-response"
-version = "0.27.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
-dependencies = [
- "async-trait",
- "futures",
- "futures-bounded 0.2.4",
+ "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "rand",
+ "libp2p-swarm",
+ "rand 0.8.5",
  "smallvec",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.43.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580189e0074af847df90e75ef54f3f30059aedda37ea5a1659e8b9fca05c0141"
+version = "0.45.2"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
- "instant",
- "libp2p-core 0.40.1",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm-derive 0.33.0",
- "log",
- "multistream-select 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell",
- "rand",
- "smallvec",
- "tokio",
- "void",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.45.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm-derive 0.35.0",
+ "libp2p-swarm-derive",
  "lru",
- "multistream-select 0.13.0 (git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d)",
+ "multistream-select",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "tokio",
  "tracing",
- "void",
  "web-time",
-]
-
-[[package]]
-name = "libp2p-swarm-derive"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d5ec2a3df00c7836d7696c136274c9c59705bac69133253696a6c932cd1d74"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-warning 0.4.2",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "libp2p-tcp"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b558dd40d1bcd1aaaed9de898e9ec6a436019ecc2420dd0016e712fbb61c5508"
-dependencies = [
- "futures",
- "futures-timer",
- "if-watch",
- "libc",
- "libp2p-core 0.40.1",
- "libp2p-identity",
- "log",
- "socket2 0.5.7",
- "tokio",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "libp2p-tcp"
 version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-tls"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8218d1d5482b122ccae396bbf38abdcb283ecc96fa54760e1dfd251f0546ac61"
-dependencies = [
- "futures",
- "futures-rustls 0.24.0",
- "libp2p-core 0.40.1",
- "libp2p-identity",
- "rcgen 0.10.0",
- "ring 0.16.20",
- "rustls 0.21.12",
- "rustls-webpki 0.101.7",
- "thiserror 1.0.65",
- "x509-parser 0.15.1",
- "yasna",
-]
-
-[[package]]
-name = "libp2p-tls"
 version = "0.5.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "futures",
- "futures-rustls 0.26.0",
- "libp2p-core 0.42.0",
+ "futures-rustls",
+ "libp2p-core",
  "libp2p-identity",
- "rcgen 0.11.3",
+ "rcgen",
  "ring 0.17.8",
  "rustls 0.23.14",
  "rustls-webpki 0.101.7",
- "thiserror 1.0.65",
+ "thiserror 2.0.12",
  "x509-parser 0.16.0",
  "yasna",
 ]
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82775a47b34f10f787ad3e2a22e2c1541e6ebef4fe9f28f3ac553921554c94c1"
+version = "0.3.1"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "futures",
  "futures-timer",
  "igd-next",
- "libp2p-core 0.40.1",
- "libp2p-swarm 0.43.7",
- "log",
- "tokio",
- "void",
-]
-
-[[package]]
-name = "libp2p-upnp"
-version = "0.3.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
-dependencies = [
- "futures",
- "futures-timer",
- "igd-next",
- "libp2p-core 0.42.0",
- "libp2p-swarm 0.45.1",
+ "libp2p-core",
+ "libp2p-swarm",
  "tokio",
  "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-wasm-ext"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5d8e3a9e07da0ef5b55a9f26c009c8fb3c725d492d8bb4b431715786eea79c"
-dependencies = [
- "futures",
- "js-sys",
- "libp2p-core 0.40.1",
- "send_wrapper",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004ee9c4a4631435169aee6aad2f62e3984dc031c43b6d29731e8e82a016c538"
+version = "0.44.1"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "either",
  "futures",
- "futures-rustls 0.24.0",
- "libp2p-core 0.40.1",
+ "futures-rustls",
+ "libp2p-core",
  "libp2p-identity",
- "log",
  "parking_lot 0.12.3",
  "pin-project-lite",
- "rw-stream-sink 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rw-stream-sink",
  "soketto",
- "thiserror 1.0.65",
+ "thiserror 2.0.12",
+ "tracing",
  "url",
  "webpki-roots 0.25.4",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eedcb62824c4300efb9cfd4e2a6edaf3ca097b9e68b36dabe45a44469fd6a85"
-dependencies = [
- "futures",
- "libp2p-core 0.40.1",
- "log",
- "thiserror 1.0.65",
- "yamux 0.12.1",
-]
-
-[[package]]
-name = "libp2p-yamux"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "either",
  "futures",
- "libp2p-core 0.42.0",
- "thiserror 1.0.65",
+ "libp2p-core",
+ "thiserror 2.0.12",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.3",
+ "yamux 0.13.5",
 ]
 
 [[package]]
@@ -6353,7 +6025,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -6462,54 +6134,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
 name = "litep2p"
-version = "0.6.2"
-source = "git+https://github.com/subspace/litep2p?rev=1ea540c6af3ed85a62355a106311740533553677#1ea540c6af3ed85a62355a106311740533553677"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14fb10e63363204b89d91e1292df83322fd9de5d7fa76c3d5c78ddc2f8f3efa9"
 dependencies = [
  "async-trait",
- "bs58 0.4.0",
+ "bs58",
  "bytes",
- "cid 0.10.1",
+ "cid 0.11.1",
  "ed25519-dalek",
  "futures",
  "futures-timer",
- "hex-literal",
- "indexmap 2.6.0",
+ "hickory-resolver 0.25.2",
+ "indexmap 2.9.0",
  "libc",
- "mockall 0.12.1",
+ "mockall 0.13.1",
  "multiaddr 0.17.1",
  "multihash 0.17.0",
  "network-interface",
- "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "prost 0.12.6",
- "prost-build 0.11.9",
- "quinn 0.9.4",
- "rand",
- "rcgen 0.10.0",
- "ring 0.16.20",
- "rustls 0.20.9",
+ "prost 0.13.5",
+ "prost-build",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
  "simple-dns",
  "smallvec",
  "snow",
- "socket2 0.5.7",
- "static_assertions",
- "thiserror 1.0.65",
+ "socket2",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
- "trust-dns-resolver",
- "uint 0.9.5",
+ "uint 0.10.0",
  "unsigned-varint 0.8.0",
  "url",
- "webpki",
  "x25519-dalek",
- "x509-parser 0.16.0",
+ "x509-parser 0.17.0",
+ "yamux 0.13.5",
  "yasna",
  "zeroize",
 ]
@@ -6546,6 +6218,19 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "loop9"
@@ -6624,7 +6309,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6638,7 +6323,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6649,7 +6334,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6660,7 +6345,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6686,12 +6371,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matrixmultiply"
@@ -6780,7 +6459,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -6833,7 +6512,7 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -6854,8 +6533,8 @@ dependencies = [
  "lioness",
  "log",
  "parking_lot 0.12.3",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_distr",
  "subtle 2.6.1",
  "thiserror 1.0.65",
@@ -6864,8 +6543,8 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "43.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "futures",
  "log",
@@ -6883,8 +6562,8 @@ dependencies = [
 
 [[package]]
 name = "mmr-rpc"
-version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "39.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -6913,15 +6592,14 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
 dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "lazy_static",
- "mockall_derive 0.12.1",
+ "mockall_derive 0.13.1",
  "predicates 3.1.2",
  "predicates-tree",
 ]
@@ -6940,14 +6618,33 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "loom",
+ "parking_lot 0.12.3",
+ "portable-atomic",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.65",
+ "uuid",
 ]
 
 [[package]]
@@ -7038,23 +6735,6 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
-dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "sha2 0.10.8",
- "sha3",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
@@ -7081,12 +6761,6 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
@@ -7094,21 +6768,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "pin-project",
- "smallvec",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multistream-select"
-version = "0.13.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "bytes",
  "futures",
@@ -7142,7 +6802,7 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7152,7 +6812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
  "clap 3.2.25",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -7161,7 +6821,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -7255,9 +6915,9 @@ dependencies = [
 
 [[package]]
 name = "network-interface"
-version = "1.1.4"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+checksum = "c3329f515506e4a2de3aa6e07027a6758e22e0f0e8eaf64fa47261cec2282602"
 dependencies = [
  "cc",
  "libc",
@@ -7399,7 +7059,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7469,7 +7129,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7623,15 +7283,6 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
-dependencies = [
- "asn1-rs 0.5.2",
-]
-
-[[package]]
-name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
@@ -7640,10 +7291,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.20.2"
+name = "oid-registry"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.1",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -7742,7 +7402,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7753,10 +7413,11 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-balances"
-version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "40.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "docify",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
@@ -7767,8 +7428,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-mmr"
-version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "39.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7783,10 +7444,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-transaction-payment"
-version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+name = "pallet-multisig"
+version = "39.1.1"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
+ "log",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+]
+
+[[package]]
+name = "pallet-transaction-payment"
+version = "39.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
+dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -7799,8 +7472,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "41.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "42.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -7815,14 +7488,29 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "39.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-api",
  "sp-runtime",
  "sp-weights",
+]
+
+[[package]]
+name = "pallet-utility"
+version = "39.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7881,8 +7569,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -7902,7 +7590,7 @@ dependencies = [
  "lz4",
  "memmap2 0.5.10",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "siphasher 0.3.11",
  "snap",
  "winapi",
@@ -7910,29 +7598,31 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "bytes",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8008,7 +7698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -8036,15 +7726,6 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
-name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
@@ -8066,27 +7747,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8152,6 +7833,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-sdk-frame"
+version = "0.8.1"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
+dependencies = [
+ "docify",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-storage",
+ "sp-transaction-pool",
+ "sp-version",
+]
+
+[[package]]
 name = "polkavm"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8200,7 +7915,7 @@ dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8210,7 +7925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8262,6 +7977,15 @@ name = "portable-atomic"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -8320,35 +8044,26 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prettyplease"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "primitive-types"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-num-traits",
  "impl-serde",
  "scale-info",
- "uint 0.9.5",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -8411,31 +8126,20 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro-warning"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "proc-macro-warning"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -8448,7 +8152,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
  "version_check",
  "yansi",
 ]
@@ -8469,7 +8173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8484,18 +8188,6 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.3",
  "thiserror 1.0.65",
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c99afa9a01501019ac3a14d71d9f94050346f55ca471ce90c799a15c58f61e2"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot 0.12.3",
- "prometheus-client-derive-encode",
 ]
 
 [[package]]
@@ -8518,17 +8210,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8542,59 +8224,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.11.9"
+name = "prost"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap 0.8.3",
- "petgraph",
- "prettyplease 0.1.25",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "bytes",
  "heck 0.5.0",
  "itertools 0.12.1",
  "log",
- "multimap 0.10.0",
+ "multimap",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.22",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.102",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -8607,25 +8263,29 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost 0.11.9",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost 0.12.6",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -8656,7 +8316,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -8684,26 +8344,13 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ededb1cd78531627244d51dd0c7139fbe736c7d57af0092a76f0ffb2f56e98"
-dependencies = [
- "asynchronous-codec 0.6.2",
- "bytes",
- "quick-protobuf",
- "thiserror 1.0.65",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
  "quick-protobuf",
- "thiserror 1.0.65",
+ "thiserror 2.0.12",
  "unsigned-varint 0.8.0",
 ]
 
@@ -8728,42 +8375,6 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8b432585672228923edbbf64b8b12c14e1112f62e88737655b4a083dbcd78e"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto 0.9.6",
- "quinn-udp 0.3.2",
- "rustc-hash 1.1.0",
- "rustls 0.20.9",
- "thiserror 1.0.65",
- "tokio",
- "tracing",
- "webpki",
-]
-
-[[package]]
-name = "quinn"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
-dependencies = [
- "bytes",
- "futures-io",
- "pin-project-lite",
- "quinn-proto 0.10.6",
- "quinn-udp 0.4.1",
- "rustc-hash 1.1.0",
- "rustls 0.21.12",
- "thiserror 1.0.65",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
@@ -8771,48 +8382,13 @@ dependencies = [
  "bytes",
  "futures-io",
  "pin-project-lite",
- "quinn-proto 0.11.8",
- "quinn-udp 0.5.5",
+ "quinn-proto",
+ "quinn-udp",
  "rustc-hash 2.0.0",
  "rustls 0.23.14",
- "socket2 0.5.7",
+ "socket2",
  "thiserror 1.0.65",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
-dependencies = [
- "bytes",
- "rand",
- "ring 0.16.20",
- "rustc-hash 1.1.0",
- "rustls 0.20.9",
- "slab",
- "thiserror 1.0.65",
- "tinyvec",
- "tracing",
- "webpki",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
-dependencies = [
- "bytes",
- "rand",
- "ring 0.16.20",
- "rustc-hash 1.1.0",
- "rustls 0.21.12",
- "slab",
- "thiserror 1.0.65",
- "tinyvec",
  "tracing",
 ]
 
@@ -8823,7 +8399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
  "rustls 0.23.14",
@@ -8835,51 +8411,31 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
-dependencies = [
- "libc",
- "quinn-proto 0.9.6",
- "socket2 0.4.10",
- "tracing",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
-dependencies = [
- "bytes",
- "libc",
- "socket2 0.5.7",
- "tracing",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "quinn-udp"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
- "socket2 0.5.7",
+ "socket2",
  "tracing",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -8894,8 +8450,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -8905,7 +8471,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -8914,7 +8490,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -8924,7 +8509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -8933,7 +8518,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -8962,8 +8547,8 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "simd_helpers",
  "system-deps 6.2.2",
  "thiserror 1.0.65",
@@ -9028,23 +8613,11 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
-dependencies = [
- "pem 1.1.1",
- "ring 0.16.20",
- "time",
- "yasna",
-]
-
-[[package]]
-name = "rcgen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
- "pem 3.0.4",
+ "pem",
  "ring 0.16.20",
  "time",
  "yasna",
@@ -9074,7 +8647,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.65",
 ]
@@ -9096,7 +8669,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -9223,7 +8796,7 @@ checksum = "5a895a7455441a857d100ca679bd24a92f91d28b5e3df63296792ac1af2eddde"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -9237,10 +8810,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.4.1",
- "hyper-rustls 0.27.3",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -9249,16 +8822,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn 0.11.5",
+ "quinn",
  "rustls 0.23.14",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -9317,7 +8890,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -9449,29 +9022,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "ring 0.16.20",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring 0.17.8",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -9501,36 +9051,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls-native-certs"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
- "base64 0.21.7",
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -9544,9 +9085,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -9563,7 +9107,7 @@ dependencies = [
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "webpki-roots 0.26.6",
  "winapi",
@@ -9605,18 +9149,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
-]
-
-[[package]]
-name = "rw-stream-sink"
-version = "0.4.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=3f6238a86bda615ee9ec54462147f6a5d7891b6d#3f6238a86bda615ee9ec54462147f6a5d7891b6d"
+source = "git+https://github.com/subspace/rust-libp2p?rev=4ff21ede371f14ea0b90075f676ae21239ef8fbf#4ff21ede371f14ea0b90075f676ae21239ef8fbf"
 dependencies = [
  "futures",
  "pin-project",
@@ -9649,8 +9182,8 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "29.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "30.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "log",
  "sp-core",
@@ -9660,8 +9193,8 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.48.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9682,8 +9215,8 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.42.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.43.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9697,8 +9230,8 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "41.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "docify",
@@ -9725,18 +9258,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "sc-client-api"
-version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "38.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "fnv",
  "futures",
@@ -9762,8 +9295,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.45.1"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9787,8 +9320,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.47.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-trait",
  "futures",
@@ -9811,8 +9344,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.47.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-trait",
  "futures",
@@ -9835,14 +9368,14 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "async-trait",
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "sc-client-api",
  "sc-consensus",
@@ -9868,7 +9401,7 @@ dependencies = [
  "subspace-kzg",
  "subspace-proof-of-space",
  "subspace-verification",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -9876,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -9904,17 +9437,24 @@ dependencies = [
  "subspace-kzg",
  "subspace-networking",
  "subspace-rpc-primitives",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "sc-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
+ "array-bytes",
+ "async-channel 1.9.0",
+ "domain-runtime-primitives",
+ "futures",
+ "parity-scale-codec",
  "sc-client-api",
  "sc-executor",
+ "sc-network",
+ "sc-network-sync",
  "sp-api",
  "sp-auto-id",
  "sp-blockchain",
@@ -9926,12 +9466,15 @@ dependencies = [
  "sp-messenger-host-functions",
  "sp-runtime",
  "sp-subspace-mmr",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.40.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.41.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -9953,8 +9496,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.35.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.36.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -9966,8 +9509,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-polkavm"
-version = "0.32.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.33.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "log",
  "polkavm",
@@ -9977,8 +9520,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.35.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.36.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9995,8 +9538,8 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.47.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "console",
  "futures",
@@ -10012,8 +9555,8 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "33.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "34.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -10026,8 +9569,8 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.15.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.18.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "arrayvec",
@@ -10055,8 +9598,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.48.4"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10069,7 +9612,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "ip_network",
- "libp2p 0.52.4",
+ "libp2p",
  "linked_hash_set",
  "litep2p",
  "log",
@@ -10080,8 +9623,8 @@ dependencies = [
  "partial_sort",
  "pin-project",
  "prost 0.12.6",
- "prost-build 0.12.6",
- "rand",
+ "prost-build",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
  "sc-network-types",
@@ -10106,15 +9649,15 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.47.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "futures",
  "libp2p-identity",
  "parity-scale-codec",
- "prost-build 0.12.6",
+ "prost-build",
  "sc-consensus",
  "sc-network-types",
  "sp-consensus",
@@ -10124,8 +9667,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.48.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -10143,8 +9686,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-light"
-version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.47.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10152,7 +9695,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "prost 0.12.6",
- "prost-build 0.12.6",
+ "prost-build",
  "sc-client-api",
  "sc-network",
  "sc-network-types",
@@ -10164,8 +9707,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-sync"
-version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.47.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10173,12 +9716,11 @@ dependencies = [
  "fork-tree",
  "futures",
  "futures-timer",
- "libp2p 0.52.4",
  "log",
  "mockall 0.11.4",
  "parity-scale-codec",
  "prost 0.12.6",
- "prost-build 0.12.6",
+ "prost-build",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
@@ -10201,8 +9743,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.47.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10220,39 +9762,42 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.12.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.15.2"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
- "bs58 0.5.1",
+ "bs58",
  "ed25519-dalek",
  "libp2p-identity",
  "litep2p",
  "log",
  "multiaddr 0.18.2",
  "multihash 0.19.1",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.65",
  "zeroize",
 ]
 
 [[package]]
 name = "sc-offchain"
-version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "43.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "bytes",
  "fnv",
  "futures",
  "futures-timer",
- "hyper 0.14.30",
- "hyper-rustls 0.24.2",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
  "log",
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
+ "rustls 0.23.14",
  "sc-client-api",
  "sc-network",
  "sc-network-common",
@@ -10272,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "core_affinity",
  "derive_more 1.0.0",
@@ -10302,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10310,8 +9855,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "40.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "43.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10342,8 +9887,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.44.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.47.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10362,8 +9907,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "17.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "20.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -10371,7 +9916,7 @@ dependencies = [
  "governor",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "ip_network",
  "jsonrpsee",
  "log",
@@ -10386,23 +9931,23 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.45.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.48.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "futures",
  "futures-util",
  "hex",
+ "itertools 0.11.0",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-rpc",
  "sc-transaction-pool-api",
- "sc-utils",
  "schnellru",
  "serde",
  "sp-api",
@@ -10418,8 +9963,8 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.46.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.49.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-trait",
  "directories",
@@ -10431,7 +9976,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-client-db",
@@ -10482,8 +10027,8 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.36.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.37.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10493,8 +10038,8 @@ dependencies = [
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.22.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.23.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "clap 4.5.20",
  "fs4 0.7.0",
@@ -10507,7 +10052,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10525,20 +10070,21 @@ dependencies = [
  "sp-runtime",
  "strum_macros",
  "subspace-core-primitives",
+ "subspace-runtime-primitives",
  "substrate-prometheus-endpoint",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 
 [[package]]
 name = "sc-subspace-sync-common"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10553,14 +10099,14 @@ dependencies = [
 
 [[package]]
 name = "sc-sysinfo"
-version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "41.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "derive_more 0.99.18",
  "futures",
  "libc",
  "log",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "regex",
  "sc-telemetry",
@@ -10574,16 +10120,16 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "25.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "28.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "chrono",
  "futures",
- "libp2p 0.52.4",
+ "libp2p",
  "log",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "sc-network",
  "sc-utils",
  "serde",
@@ -10594,13 +10140,12 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "37.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "38.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "chrono",
  "console",
  "is-terminal",
- "lazy_static",
  "libc",
  "log",
  "parity-scale-codec",
@@ -10624,22 +10169,24 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
-version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "38.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
+ "indexmap 2.9.0",
+ "itertools 0.11.0",
  "linked-hash-map",
  "log",
  "parity-scale-codec",
@@ -10657,12 +10204,14 @@ dependencies = [
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.65",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "38.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-trait",
  "futures",
@@ -10677,13 +10226,12 @@ dependencies = [
 
 [[package]]
 name = "sc-utils"
-version = "17.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "18.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
  "futures-timer",
- "lazy_static",
  "log",
  "parking_lot 0.12.3",
  "prometheus",
@@ -10692,13 +10240,13 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.3"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "bitvec",
  "cfg-if",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "parity-scale-codec",
  "scale-info-derive",
  "serde",
@@ -10706,14 +10254,14 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.3"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -10727,9 +10275,9 @@ dependencies = [
 
 [[package]]
 name = "schnellru"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
+checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
 dependencies = [
  "ahash 0.8.11",
  "cfg-if",
@@ -10748,7 +10296,7 @@ dependencies = [
  "curve25519-dalek",
  "getrandom_or_panic",
  "merlin",
- "rand_core",
+ "rand_core 0.6.4",
  "serde_bytes",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -10756,20 +10304,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "sec1"
@@ -10828,10 +10372,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework-sys"
-version = "2.12.0"
+name = "security-framework"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -10850,12 +10407,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-
-[[package]]
 name = "seq-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10863,9 +10414,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -10890,13 +10441,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -10919,7 +10470,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -11039,7 +10590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -11072,9 +10623,9 @@ dependencies = [
 
 [[package]]
 name = "simple-dns"
-version = "0.5.7"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae9a3fcdadafb6d97f4c0e007e4247b114ee0f119f650c3cbf3a8b3a1479694"
+checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -11123,9 +10674,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snap"
@@ -11143,7 +10694,7 @@ dependencies = [
  "blake2 0.10.6",
  "chacha20poly1305",
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "ring 0.17.8",
  "rustc_version",
  "sha2 0.10.8",
@@ -11152,19 +10703,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -11182,14 +10723,14 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
 ]
 
 [[package]]
 name = "sp-api"
-version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "35.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "docify",
  "hash-db",
@@ -11210,8 +10751,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "21.0.2"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -11219,13 +10760,13 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "sp-application-crypto"
-version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "39.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11237,7 +10778,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -11251,7 +10792,7 @@ dependencies = [
 [[package]]
 name = "sp-auto-id"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11264,8 +10805,8 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "35.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -11275,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "sp-block-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -11286,8 +10827,8 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "37.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "38.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -11305,8 +10846,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.40.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.41.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-trait",
  "futures",
@@ -11319,11 +10860,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus-beefy"
-version = "22.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+name = "sp-consensus-aura"
+version = "0.41.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
- "lazy_static",
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus-slots",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
+]
+
+[[package]]
+name = "sp-consensus-beefy"
+version = "23.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
+dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -11341,8 +10897,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "22.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11358,8 +10914,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.40.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.41.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11370,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "async-trait",
  "log",
@@ -11392,19 +10948,19 @@ dependencies = [
  "subspace-kzg",
  "subspace-proof-of-space",
  "subspace-verification",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "sp-core"
-version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "35.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "bounded-collections",
- "bs58 0.5.1",
+ "bs58",
  "dyn-clonable",
  "ed25519-zebra",
  "futures",
@@ -11421,7 +10977,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel",
  "secp256k1",
@@ -11434,7 +10990,7 @@ dependencies = [
  "sp-std",
  "sp-storage",
  "ss58-registry",
- "substrate-bip39 0.6.0 (git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305)",
+ "substrate-bip39 0.6.0 (git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba)",
  "thiserror 1.0.65",
  "tracing",
  "w3f-bls",
@@ -11444,7 +11000,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -11457,17 +11013,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -11476,17 +11032,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -11495,7 +11051,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-sudo"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11506,17 +11062,17 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "blake2 0.10.6",
  "domain-runtime-primitives",
  "frame-support",
  "hash-db",
- "hexlit",
+ "hex-literal",
  "memory-db",
  "parity-scale-codec",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rs_merkle",
  "scale-info",
  "serde",
@@ -11538,8 +11094,9 @@ dependencies = [
 [[package]]
 name = "sp-domains-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
+ "domain-block-builder",
  "domain-block-preprocessor",
  "domain-runtime-primitives",
  "frame-support",
@@ -11566,14 +11123,29 @@ dependencies = [
  "sp-weights",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "trie-db",
+]
+
+[[package]]
+name = "sp-evm-tracker"
+version = "0.1.0"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
+dependencies = [
+ "async-trait",
+ "domain-runtime-primitives",
+ "frame-support",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-domains",
+ "sp-inherents",
+ "sp-weights",
 ]
 
 [[package]]
 name = "sp-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11582,8 +11154,8 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.29.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.30.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11592,8 +11164,8 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.15.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.16.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11604,8 +11176,8 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "35.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11617,8 +11189,8 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "38.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "39.0.1"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "bytes",
  "docify",
@@ -11642,9 +11214,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-keyring"
+version = "40.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
+dependencies = [
+ "sp-core",
+ "sp-runtime",
+ "strum",
+]
+
+[[package]]
 name = "sp-keystore"
-version = "0.40.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.41.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -11655,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "thiserror 1.0.65",
  "zstd 0.12.4",
@@ -11664,7 +11246,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -11686,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger-host-functions"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "domain-block-preprocessor",
  "parity-scale-codec",
@@ -11704,8 +11286,8 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.7.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.8.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -11714,8 +11296,8 @@ dependencies = [
 
 [[package]]
 name = "sp-mixnet"
-version = "0.12.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.13.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11725,8 +11307,8 @@ dependencies = [
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "34.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "35.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11743,7 +11325,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "sp-api",
  "subspace-core-primitives",
@@ -11752,8 +11334,8 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "35.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11762,18 +11344,17 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "13.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "13.0.1"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "backtrace",
- "lazy_static",
  "regex",
 ]
 
 [[package]]
 name = "sp-rpc"
-version = "32.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "33.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -11782,9 +11363,10 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "39.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "40.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
+ "binary-merkle-tree",
  "docify",
  "either",
  "hash256-std-hasher",
@@ -11793,7 +11375,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -11802,14 +11384,16 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-std",
+ "sp-trie",
  "sp-weights",
  "tracing",
+ "tuplex",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
-version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "29.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11828,20 +11412,20 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "sp-session"
-version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "37.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11854,8 +11438,8 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "36.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "37.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -11867,14 +11451,14 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.43.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.44.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "sp-core",
  "sp-externalities",
@@ -11887,15 +11471,15 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "18.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "19.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
  "sp-api",
@@ -11912,12 +11496,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 
 [[package]]
 name = "sp-storage"
-version = "21.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "22.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11929,7 +11513,7 @@ dependencies = [
 [[package]]
 name = "sp-subspace-mmr"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11945,8 +11529,8 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "35.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11958,7 +11542,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -11968,8 +11552,8 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "35.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -11977,8 +11561,8 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "34.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "35.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11991,17 +11575,16 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "38.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
- "lazy_static",
  "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnellru",
  "sp-core",
@@ -12014,8 +11597,8 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "37.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "38.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12031,20 +11614,20 @@ dependencies = [
 
 [[package]]
 name = "sp-version-proc-macro"
-version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "15.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "parity-scale-codec",
- "proc-macro-warning 1.0.2",
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -12056,7 +11639,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -12069,7 +11652,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12147,7 +11730,7 @@ dependencies = [
  "subspace-service",
  "sys-locale",
  "tempfile",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "thread-priority",
  "tokio",
  "tracing",
@@ -12224,13 +11807,15 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-xcm"
-version = "14.2.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "15.1.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "array-bytes",
  "bounded-collections",
  "derivative",
  "environmental",
+ "frame-support",
+ "hex-literal",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
@@ -12306,27 +11891,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "parity-scale-codec",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "subspace-core-primitives",
  "subspace-erasure-coding",
  "subspace-kzg",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "blake3",
  "bytes",
@@ -12345,7 +11931,7 @@ dependencies = [
 [[package]]
 name = "subspace-data-retrieval"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12355,7 +11941,7 @@ dependencies = [
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-erasure-coding",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -12363,7 +11949,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "kzg",
  "rust-kzg-blst",
@@ -12374,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "subspace-fake-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "domain-runtime-primitives",
  "frame-support",
@@ -12384,7 +11970,6 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "sp-api",
  "sp-block-builder",
- "sp-blockchain",
  "sp-consensus-subspace",
  "sp-core",
  "sp-domains",
@@ -12406,7 +11991,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -12430,8 +12015,8 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
- "prometheus-client 0.22.3",
- "rand",
+ "prometheus-client",
+ "rand 0.8.5",
  "rayon",
  "schnorrkel",
  "serde",
@@ -12450,7 +12035,7 @@ dependencies = [
  "subspace-verification",
  "substrate-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "thread-priority",
  "tokio",
  "tokio-stream",
@@ -12462,7 +12047,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -12474,7 +12059,7 @@ dependencies = [
  "libc",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "schnorrkel",
  "serde",
@@ -12486,7 +12071,7 @@ dependencies = [
  "subspace-kzg",
  "subspace-proof-of-space",
  "subspace-verification",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "winapi",
@@ -12495,7 +12080,7 @@ dependencies = [
 [[package]]
 name = "subspace-kzg"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "derive_more 1.0.0",
  "kzg",
@@ -12510,7 +12095,7 @@ dependencies = [
 [[package]]
 name = "subspace-logging"
 version = "0.0.1"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "supports-color",
  "tracing",
@@ -12520,18 +12105,18 @@ dependencies = [
 [[package]]
 name = "subspace-metrics"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "actix-web",
  "prometheus",
- "prometheus-client 0.22.3",
+ "prometheus-client",
  "tracing",
 ]
 
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -12544,22 +12129,22 @@ dependencies = [
  "futures",
  "futures-timer",
  "hex",
- "libp2p 0.54.1",
+ "libp2p",
  "memmap2 0.9.5",
  "multihash 0.19.1",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
- "prometheus-client 0.22.3",
- "rand",
+ "prometheus-client",
+ "rand 0.8.5",
  "schnellru",
  "serde",
  "serde_json",
  "subspace-core-primitives",
  "subspace-logging",
  "subspace-metrics",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -12570,8 +12155,9 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
+ "blake3",
  "chacha20",
  "derive_more 1.0.0",
  "parking_lot 0.12.3",
@@ -12579,14 +12165,13 @@ dependencies = [
  "seq-macro",
  "sha2 0.10.8",
  "spin 0.9.8",
- "static_assertions",
  "subspace-core-primitives",
 ]
 
 [[package]]
 name = "subspace-proof-of-space-gpu"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "blst",
  "cc",
@@ -12599,17 +12184,18 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "aes 0.9.0-pre.2",
+ "cpufeatures",
  "subspace-core-primitives",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -12622,11 +12208,14 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "frame-support",
  "frame-system",
+ "pallet-balances",
+ "pallet-multisig",
  "pallet-transaction-payment",
+ "pallet-utility",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -12638,7 +12227,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -12647,6 +12236,7 @@ dependencies = [
  "async-trait",
  "cross-domain-message-gossip",
  "domain-runtime-primitives",
+ "frame-support",
  "frame-system-rpc-runtime-api",
  "futures",
  "hex",
@@ -12657,11 +12247,12 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "prometheus-client 0.22.3",
+ "prometheus-client",
  "rayon",
  "sc-basic-authorship",
  "sc-chain-spec",
  "sc-client-api",
+ "sc-client-db",
  "sc-consensus",
  "sc-consensus-slots",
  "sc-consensus-subspace",
@@ -12685,6 +12276,7 @@ dependencies = [
  "sc-transaction-pool-api",
  "schnellru",
  "schnorrkel",
+ "serde_json",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
@@ -12718,7 +12310,7 @@ dependencies = [
  "subspace-verification",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -12726,14 +12318,14 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=eed2c70f14e1a47ed845ec1557718869082dc2b1#eed2c70f14e1a47ed845ec1557718869082dc2b1"
+source = "git+https://github.com/subspace/subspace?rev=6609138bb8286374297cf4935d72aac872136376#6609138bb8286374297cf4935d72aac872136376"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
  "subspace-core-primitives",
  "subspace-kzg",
  "subspace-proof-of-space",
- "thiserror 2.0.1",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -12752,7 +12344,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -12763,8 +12355,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "39.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "42.0.0"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -12783,11 +12375,11 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.17.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "0.17.1"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
  "log",
  "prometheus",
@@ -12829,9 +12421,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12867,7 +12459,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -12925,6 +12517,12 @@ dependencies = [
  "toml 0.8.19",
  "version-compare",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -13005,11 +12603,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.1"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c1e40dd48a282ae8edc36c732cbc219144b87fb6a4c7316d611c6b1f06ec0c"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.1",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -13020,18 +12618,18 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.1"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874aa7e446f1da8d9c3a5c95b1c5eb41d800045252121dc7f8e0ba370cee55f5"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -13128,6 +12726,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13144,9 +12752,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -13155,7 +12763,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.52.0",
@@ -13163,23 +12771,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -13207,24 +12805,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
+ "rustls 0.23.14",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tungstenite",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -13270,7 +12869,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -13281,7 +12880,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -13312,7 +12911,7 @@ dependencies = [
  "bitflags 2.6.0",
  "bytes",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "pin-project-lite",
  "tower-layer",
@@ -13351,7 +12950,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -13432,7 +13031,7 @@ checksum = "dc19eb2373ccf3d1999967c26c3d44534ff71ae5d8b9dacf78f4b13132229e48"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -13477,78 +13076,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner 0.5.1",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "rand",
- "smallvec",
- "socket2 0.4.10",
- "thiserror 1.0.65",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner 0.6.1",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand",
- "smallvec",
- "thiserror 1.0.65",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot 0.12.3",
- "rand",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.65",
- "tokio",
- "tracing",
- "trust-dns-proto 0.23.2",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13562,23 +13089,29 @@ checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.12",
+ "http 1.1.0",
  "httparse",
  "log",
- "rand",
- "rustls 0.21.12",
+ "rand 0.9.1",
+ "rustls 0.23.14",
+ "rustls-pki-types",
  "sha1",
- "thiserror 1.0.65",
+ "thiserror 2.0.12",
  "url",
  "utf-8",
 ]
+
+[[package]]
+name = "tuplex"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "676ac81d5454c4dcf37955d34fa8626ede3490f744b86ca14a7b90168d2a08aa"
 
 [[package]]
 name = "twox-hash"
@@ -13588,7 +13121,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -13648,8 +13181,8 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
 dependencies = [
- "getrandom",
- "rand",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
  "serde",
  "web-time",
 ]
@@ -13670,7 +13203,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a5422c1f65949306c99240b81de9f3f15929f5a8bfe05bb44b034cc8bf593e5"
 dependencies = [
- "tinystr",
+ "tinystr 0.7.6",
 ]
 
 [[package]]
@@ -13680,7 +13213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da1cd2c042d3c7569a1008806b02039e7a4a2bdf8f8e96bd3c792434a0e275e"
 dependencies = [
  "proc-macro-hack",
- "tinystr",
+ "tinystr 0.7.6",
  "unic-langid-impl",
  "unic-langid-macros-impl",
 ]
@@ -13693,7 +13226,7 @@ checksum = "1ed7f4237ba393424195053097c1516bd4590dc82b84f2f97c5c69e12704555b"
 dependencies = [
  "proc-macro-hack",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
  "unic-langid-impl",
 ]
 
@@ -13785,12 +13318,12 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna 1.0.3",
  "percent-encoding",
 ]
 
@@ -13801,10 +13334,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "v_frame"
@@ -13866,9 +13414,9 @@ dependencies = [
  "arrayref",
  "constcat",
  "digest 0.10.7",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",
  "thiserror 1.0.65",
@@ -13901,6 +13449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13922,7 +13479,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
  "wasm-bindgen-shared",
 ]
 
@@ -13956,7 +13513,7 @@ checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -14176,7 +13733,7 @@ dependencies = [
  "memfd",
  "memoffset 0.8.0",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rustix 0.36.17",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -14214,16 +13771,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -14337,6 +13884,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14360,10 +13929,34 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -14374,7 +13967,18 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -14385,7 +13989,34 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -14395,7 +14026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result 0.2.0",
- "windows-strings",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -14418,6 +14049,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14428,18 +14068,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.42.0"
+name = "windows-strings"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -14522,6 +14156,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -14712,10 +14355,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wyz"
@@ -14743,26 +14401,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
-dependencies = [
- "asn1-rs 0.5.2",
- "data-encoding",
- "der-parser 8.2.0",
- "lazy_static",
- "nom",
- "oid-registry 0.6.1",
- "rusticata-macros",
- "thiserror 1.0.65",
- "time",
 ]
 
 [[package]]
@@ -14784,6 +14425,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+dependencies = [
+ "asn1-rs 0.7.1",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
+ "rusticata-macros",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14796,13 +14454,13 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "10.1.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=94a1a8143a89bbe9f938c1939ff68abc1519a305#94a1a8143a89bbe9f938c1939ff68abc1519a305"
+version = "11.0.1"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=e831132867930ca90a7088c7246301ab29f015ba#e831132867930ca90a7088c7246301ab29f015ba"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -14841,22 +14499,22 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
 [[package]]
 name = "yamux"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31b5e376a8b012bee9c423acdbb835fc34d45001cfa3106236a624e4b738028"
+checksum = "3da1acad1c2dc53f0dde419115a38bd8221d8c3e47ae9aeceaf453266d29307e"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.9.1",
  "static_assertions",
  "web-time",
 ]
@@ -14874,6 +14532,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -14900,7 +14582,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",
@@ -14953,7 +14635,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
  "zvariant_utils 2.1.0",
 ]
 
@@ -14966,7 +14648,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
  "zbus_names 4.1.0",
  "zvariant 5.1.0",
  "zvariant_utils 3.0.2",
@@ -15013,7 +14695,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -15033,7 +14736,40 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -15055,15 +14791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zstd"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
-dependencies = [
- "zstd-safe 7.2.1",
-]
-
-[[package]]
 name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15080,15 +14807,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
-dependencies = [
  "zstd-sys",
 ]
 
@@ -15163,7 +14881,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
  "zvariant_utils 2.1.0",
 ]
 
@@ -15176,7 +14894,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
  "zvariant_utils 3.0.2",
 ]
 
@@ -15188,7 +14906,7 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -15201,6 +14919,6 @@ dependencies = [
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.87",
+ "syn 2.0.102",
  "winnow 0.6.20",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "space-acres"
 description = "Space Acres is an opinionated GUI application for farming on Autonomys Network"
 license = "0BSD"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/autonomys/space-acres"
-edition = "2021"
+edition = "2024"
 include = [
     "/src",
     "/Cargo.toml",
@@ -39,7 +39,7 @@ anyhow = "1.0.91"
 arc-swap = "1.7.1"
 async-lock = "3.4.0"
 async-oneshot = "0.5.9"
-async-trait = "0.1.83"
+async-trait = "0.1.88"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytesize = "1.3.0"
 clap = { version = "4.5.20", features = ["derive"] }
@@ -51,7 +51,7 @@ fdlimit = "0.3.0"
 file-rotate = "0.7.6"
 fluent-langneg = "0.14.1"
 fluent-static = "0.4.0"
-frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
 fs4 = "0.10.0"
 futures = "0.3.31"
 futures-timer = "3.0.3"
@@ -62,49 +62,49 @@ mimalloc = "0.1.43"
 names = "0.14.0"
 notify-rust = { version = "4.11.3", features = ["images"] }
 open = "5.3.0"
-pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
+pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
 parity-scale-codec = "3.6.12"
 parking_lot = "0.12.3"
 relm4 = "0.9.1"
 relm4-components = { version = "0.9.1", default-features = false }
 relm4-icons = "0.10.0-beta.2"
 reqwest = { version = "0.12.8", default-features = false, features = ["json", "rustls-tls"] }
-sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sc-network-types = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-schnellru = "0.2.3"
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sc-network-types = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+schnellru = "0.2.4"
 semver = "1.0.23"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 simple_moving_average = "1.0.2"
-sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-sp-objects = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-data-retrieval = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-fake-runtime-api = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1", default-features = false }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-kzg = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-proof-of-space-gpu = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1", optional = true }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "eed2c70f14e1a47ed845ec1557718869082dc2b1" }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+sp-objects = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-data-retrieval = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-fake-runtime-api = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376", default-features = false }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-kzg = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-proof-of-space-gpu = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376", optional = true }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "6609138bb8286374297cf4935d72aac872136376" }
 sys-locale = "0.3.1"
 tempfile = "3.13.0"
 thiserror = "2.0.1"
@@ -213,18 +213,34 @@ zeroize = { opt-level = 3 }
 inherits = "release"
 lto = "fat"
 
-# TODO: Remove fork when https://github.com/paritytech/polkadot-sdk/issues/4856 and/or https://github.com/paritytech/litep2p/issues/161
-#  are resolved (our fork removes WebRTC support by default in order to avoid OpenSSL dependency)
 [patch.crates-io]
-litep2p = { git = "https://github.com/subspace/litep2p", rev = "1ea540c6af3ed85a62355a106311740533553677" }
+# Patch away `libp2p-identity` in our dependency tree with the git version.
+# For details see: https://github.com/subspace/rust-libp2p/blob/4ff21ede371f14ea0b90075f676ae21239ef8fbf/Cargo.toml#L140-L145
+libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf" }
 # TODO: Remove once something newer than 0.15.3 is released with support for `NUMBER()` built-in function and used in `fluent-static`
 fluent-bundle = { git = "https://github.com/projectfluent/fluent-rs", rev = "bda4736095a4a60a9a042b336d0789c22461905d" }
 
 # Reason: We need to patch substrate dependency of frontier to our fork
 # TODO: Remove if/when we are using upstream substrate instead of fork
 [patch."https://github.com/paritytech/polkadot-sdk.git"]
-sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
-sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
-sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
-sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
-staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
+frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+sp-runtime-interface = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+sp-storage = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+staging-xcm = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba" }
+
+[patch."https://github.com/autonomys/rust-libp2p.git"]
+# Patch away `libp2p` in our dependency tree with the git version.
+# This brings the fixes in our `libp2p` fork into substrate's dependencies.
+#
+# This is a hack: patches to the same repository are rejected by `cargo`. But it considers
+# "subspace/rust-libp2p" and "autonomys/rust-libp2p" to be different repositories, even though
+# they're redirected to the same place by GitHub, so it allows this patch.
+libp2p = { git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf" }
+libp2p-identity = { git = "https://github.com/subspace/rust-libp2p", rev = "4ff21ede371f14ea0b90075f676ae21239ef8fbf" }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use fluent_static_codegen::{generate, MessageBundleCodeGenerator};
+use fluent_static_codegen::{MessageBundleCodeGenerator, generate};
 use std::path::Path;
 use std::{env, fs};
 

--- a/res/windows/wix/expected-dlls.log
+++ b/res/windows/wix/expected-dlls.log
@@ -28,7 +28,6 @@ intl.dll
 jpeg62.dll
 libexpat.dll
 libpng16.dll
-libxml2.dll
 pango-1.0-0.dll
 pangocairo-1.0-0.dll
 pangowin32-1.0-0.dll
@@ -37,9 +36,10 @@ pcre2-32-0.dll
 pcre2-8-0.dll
 pcre2-posix-3.dll
 pixman-1-0.dll
-pkgconf-5.dll
+pkgconf-6.dll
 rsvg-2-2.dll
 textstyle.dll
 tiff.dll
 turbojpeg.dll
+xml2-16.dll
 zlib1.dll

--- a/res/windows/wix/space-acres.wxs
+++ b/res/windows/wix/space-acres.wxs
@@ -210,9 +210,6 @@
                         <Component Id='gtk4_libpng16.dll' Guid='f1eb894a-fd88-469d-81ea-640791560a1e'>
                             <File Id='libpng16.dll' Name='libpng16.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\libpng16.dll' />
                         </Component>
-                        <Component Id='gtk4_libxml2.dll' Guid='dfb79114-fe77-480d-8118-050bd86c3aa5'>
-                            <File Id='libxml2.dll' Name='libxml2.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\libxml2.dll' />
-                        </Component>
                         <Component Id='gtk4_pango_1.0_0.dll' Guid='9f680fdc-42a1-4efa-a526-c04a4a9eb68f'>
                             <File Id='pango_1.0_0.dll' Name='pango-1.0-0.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\pango-1.0-0.dll' />
                         </Component>
@@ -237,8 +234,8 @@
                         <Component Id='gtk4_pixman_1_0.dll' Guid='9f6dff89-ea6e-4355-9863-f076e915697d'>
                             <File Id='pixman_1_0.dll' Name='pixman-1-0.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\pixman-1-0.dll' />
                         </Component>
-                        <Component Id='gtk4_pkgconf_5.dll' Guid='9c5ef299-8a73-4c79-8cc5-a48b9833c5a9'>
-                            <File Id='pkgconf_5.dll' Name='pkgconf-5.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\pkgconf-5.dll' />
+                        <Component Id='gtk4_pkgconf_6.dll' Guid='2b0ab36a-d1d0-427f-a63c-6dfd513b8b82'>
+                            <File Id='pkgconf_6.dll' Name='pkgconf-6.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\pkgconf-6.dll' />
                         </Component>
                         <Component Id='gtk4_rsvg_2_2.dll' Guid='c45c78c2-1b52-4bb8-b165-64229cacb357'>
                             <File Id='rsvg_2_2.dll' Name='rsvg-2-2.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\rsvg-2-2.dll' />
@@ -251,6 +248,9 @@
                         </Component>
                         <Component Id='gtk4_turbojpeg.dll' Guid='914f9fc2-a3e4-47a7-85b6-e63f2d901bcb'>
                             <File Id='turbojpeg.dll' Name='turbojpeg.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\turbojpeg.dll' />
+                        </Component>
+                         <Component Id='gtk4_xml2_16.dll' Guid='6c9abb1f-ca51-4054-b148-f368c3661eed'>
+                            <File Id='xml2_16.dll' Name='xml2-16.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\xml2-16.dll' />
                         </Component>
                         <Component Id='gtk4_zlib1.dll' Guid='b83feda4-4cc4-4ef1-9c95-ce74b785f6d9'>
                             <File Id='zlib1.dll' Name='zlib1.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\zlib1.dll' />
@@ -382,7 +382,6 @@
             <ComponentRef Id='gtk4_jpeg62.dll'/>
             <ComponentRef Id='gtk4_libexpat.dll'/>
             <ComponentRef Id='gtk4_libpng16.dll'/>
-            <ComponentRef Id='gtk4_libxml2.dll'/>
             <ComponentRef Id='gtk4_pango_1.0_0.dll'/>
             <ComponentRef Id='gtk4_pangocairo_1.0_0.dll'/>
             <ComponentRef Id='gtk4_pangowin32_1.0_0.dll'/>
@@ -391,11 +390,12 @@
             <ComponentRef Id='gtk4_pcre2_8_0.dll'/>
             <ComponentRef Id='gtk4_pcre2_posix_3.dll'/>
             <ComponentRef Id='gtk4_pixman_1_0.dll'/>
-            <ComponentRef Id='gtk4_pkgconf_5.dll'/>
+            <ComponentRef Id='gtk4_pkgconf_6.dll'/>
             <ComponentRef Id='gtk4_rsvg_2_2.dll'/>
             <ComponentRef Id='gtk4_textstyle.dll'/>
             <ComponentRef Id='gtk4_tiff.dll'/>
             <ComponentRef Id='gtk4_turbojpeg.dll'/>
+            <ComponentRef Id='gtk4_xml2_16.dll'/>
             <ComponentRef Id='gtk4_zlib1.dll'/>
             <ComponentRef Id='gdk_pixbuf_loaders'/>
             <ComponentRef Id='glib_2.gdk_pixbuf_loaders.cache'/>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-12-24"
+channel = "nightly-2025-05-31"
 components = ["rust-src"]
 targets = []
 profile = "default"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-edition = "2021"
+edition = "2024"
 imports_granularity = "Module"

--- a/src/backend/node.rs
+++ b/src/backend/node.rs
@@ -1,13 +1,13 @@
 mod utils;
 
+use crate::PosTable;
 use crate::backend::farmer::direct_node_client::{DirectNodeClient, NodeClientConfig};
 use crate::backend::farmer::maybe_node_client::MaybeNodeClient;
 use crate::backend::node::utils::account_storage_key;
 use crate::backend::utils::{Handler, HandlerFn};
-use crate::PosTable;
 use event_listener_primitives::HandlerId;
 use frame_system::AccountInfo;
-use futures::{select, FutureExt, StreamExt};
+use futures::{FutureExt, StreamExt, select};
 use names::{Generator, Name};
 use pallet_balances::AccountData;
 use parity_scale_codec::Decode;
@@ -22,23 +22,23 @@ use sc_storage_monitor::{StorageMonitorParams, StorageMonitorService};
 use serde_json::Value;
 use sp_api::ProvideRuntimeApi;
 use sp_consensus_subspace::{ChainConstants, SubspaceApi};
+use sp_core::H256;
 use sp_core::crypto::Ss58AddressFormat;
 use sp_core::storage::StorageKey;
-use sp_core::H256;
 use sp_runtime::traits::Header;
 use std::fmt;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use subspace_core_primitives::solutions::SolutionRange;
 use subspace_core_primitives::{BlockNumber, PublicKey};
 use subspace_data_retrieval::piece_getter::PieceGetter;
 use subspace_fake_runtime_api::RuntimeApi;
-use subspace_networking::libp2p::identity::ed25519::Keypair;
-use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::Node;
+use subspace_networking::libp2p::Multiaddr;
+use subspace_networking::libp2p::identity::ed25519::Keypair;
 use subspace_runtime_primitives::{Balance, Nonce};
 use subspace_service::config::{
     ChainSyncMode, SubspaceConfiguration, SubspaceNetworking, SubstrateConfiguration,
@@ -382,6 +382,7 @@ fn set_default_ss58_version(chain_spec: &ChainSpec) {
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn pot_external_entropy(chain_spec: &ChainSpec) -> Result<Vec<u8>, sc_service::Error> {
     let maybe_chain_spec_pot_external_entropy = chain_spec
         .0
@@ -401,6 +402,7 @@ fn pot_external_entropy(chain_spec: &ChainSpec) -> Result<Vec<u8>, sc_service::E
         .into_bytes())
 }
 
+#[allow(clippy::result_large_err)]
 pub(super) fn dsn_bootstrap_nodes(
     chain_spec: &ChainSpec,
 ) -> Result<Vec<Multiaddr>, sc_service::Error> {
@@ -496,6 +498,8 @@ fn create_consensus_chain_config(
         telemetry_endpoints,
         force_authoring: false,
         chain_spec: chain_spec.into(),
+        executor: Default::default(),
+        trie_cache_size: None,
     }
 }
 

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -8,13 +8,13 @@ mod widgets;
 
 use crate::backend::config::RawConfig;
 use crate::backend::farmer::FarmerAction;
-use crate::backend::{wipe, BackendAction, BackendNotification};
+use crate::backend::{BackendAction, BackendNotification, wipe};
 use crate::frontend::configuration::{ConfigurationInput, ConfigurationOutput, ConfigurationView};
 use crate::frontend::loading::{LoadingInput, LoadingView};
 use crate::frontend::new_version::NewVersion;
 use crate::frontend::running::{RunningInit, RunningInput, RunningOutput, RunningView};
 use crate::frontend::translations::{AsDefaultStr, T};
-use crate::{icon_names, AppStatusCode};
+use crate::{AppStatusCode, icon_names};
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
 use gtk::glib;
@@ -125,6 +125,7 @@ pub enum AppInput {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum AppCommandOutput {
     BackendNotification(BackendNotification),
     ShowWindow,
@@ -572,27 +573,29 @@ impl AsyncComponent for App {
             .website_label("GitHub")
             .comments(env!("CARGO_PKG_DESCRIPTION"))
             .logo(&*PIXBUF_ABOUT_IMG)
-            .system_information({
-                let config_directory = dirs::config_local_dir()
-                    .map(|config_local_dir| {
-                        config_local_dir
-                            .join(env!("CARGO_PKG_NAME"))
-                            .display()
-                            .to_string()
-                    })
-                    .unwrap_or_else(|| "Unknown".to_string());
-                let data_directory = dirs::data_local_dir()
-                    .map(|data_local_dir| {
-                        data_local_dir
-                            .join(env!("CARGO_PKG_NAME"))
-                            .display()
-                            .to_string()
-                    })
-                    .unwrap_or_else(|| "Unknown".to_string());
+            .system_information(
+                {
+                    let config_directory = dirs::config_local_dir()
+                        .map(|config_local_dir| {
+                            config_local_dir
+                                .join(env!("CARGO_PKG_NAME"))
+                                .display()
+                                .to_string()
+                        })
+                        .unwrap_or_else(|| "Unknown".to_string());
+                    let data_directory = dirs::data_local_dir()
+                        .map(|data_local_dir| {
+                            data_local_dir
+                                .join(env!("CARGO_PKG_NAME"))
+                                .display()
+                                .to_string()
+                        })
+                        .unwrap_or_else(|| "Unknown".to_string());
 
-                T.about_system_information(config_directory, data_directory)
-                    .as_str()
-            })
+                    T.about_system_information(config_directory, data_directory)
+                }
+                .as_str(),
+            )
             .transient_for(&root)
             .build();
 
@@ -783,7 +786,9 @@ impl AsyncComponent for App {
                 }
             }
             AppInput::OpenCommunityHelpLink => {
-                if let Err(error) = open::that_detached("https://docs.autonomys.xyz/docs/farming-&-staking/farming/space-acres/space-acres-install#troubleshooting") {
+                if let Err(error) = open::that_detached(
+                    "https://docs.autonomys.xyz/docs/farming-&-staking/farming/space-acres/space-acres-install#troubleshooting",
+                ) {
                     error!(%error, "Failed to open share community help in default browser");
                 }
             }
@@ -825,7 +830,6 @@ impl AsyncComponent for App {
                     root.set_visible(false);
                 } else {
                     root.present();
-
                 }
             }
             AppInput::ShutDown => {

--- a/src/frontend/running.rs
+++ b/src/frontend/running.rs
@@ -5,13 +5,13 @@ use crate::backend::config::{Config, RawConfig};
 use crate::backend::farmer::{FarmerNotification, InitialFarmState};
 use crate::backend::node::ChainInfo;
 use crate::backend::{FarmIndex, NodeNotification};
+use crate::frontend::NotificationExt;
 use crate::frontend::running::farm::{FarmWidget, FarmWidgetInit, FarmWidgetInput};
 use crate::frontend::running::node::{NodeInput, NodeView};
 use crate::frontend::translations::{AsDefaultStr, T};
 use crate::frontend::widgets::progress_circle::{
     ProgressCircle, ProgressCircleInit, ProgressCircleInput,
 };
-use crate::frontend::NotificationExt;
 use crate::icon_names;
 use gtk::prelude::*;
 use notify_rust::Notification;
@@ -20,13 +20,13 @@ use relm4::prelude::*;
 use sp_consensus_subspace::ChainConstants;
 use std::num::NonZeroU8;
 use std::time::{Duration, Instant};
-use subspace_core_primitives::pieces::Piece;
-use subspace_core_primitives::solutions::{solution_range_to_pieces, SolutionRange};
 use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::pieces::Piece;
+use subspace_core_primitives::solutions::{SolutionRange, solution_range_to_pieces};
 use subspace_farmer::farm::{
     FarmingNotification, ProvingResult, SectorPlottingDetails, SectorUpdate,
 };
-use subspace_runtime_primitives::{Balance, SSC};
+use subspace_runtime_primitives::{AI3, Balance};
 use tracing::{debug, warn};
 
 #[derive(Debug)]
@@ -175,8 +175,8 @@ impl Component for RunningView {
                                 set_label: &{
                                     let current_balance = model.farmer_state.reward_address_balance;
                                     let balance_increase = model.farmer_state.reward_address_balance - model.farmer_state.initial_reward_address_balance;
-                                    let current_balance = (current_balance / (SSC / 100)) as f32 / 100.0;
-                                    let balance_increase = (balance_increase / (SSC / 100)) as f32 / 100.0;
+                                    let current_balance = (current_balance / (AI3 / 100)) as f32 / 100.0;
+                                    let balance_increase = (balance_increase / (AI3 / 100)) as f32 / 100.0;
                                     let token_symbol = &model.farmer_state.token_symbol;
 
                                     format!(

--- a/src/frontend/running/farm.rs
+++ b/src/frontend/running/farm.rs
@@ -1,13 +1,13 @@
 use crate::backend::farmer::DiskFarm;
-use crate::frontend::translations::{AsDefaultStr, T};
 use crate::frontend::NotificationExt;
+use crate::frontend::translations::{AsDefaultStr, T};
 use crate::icon_names;
 use bytesize::ByteSize;
 use gtk::prelude::*;
 use notify_rust::Notification;
 use relm4::prelude::*;
 use relm4::{RelmIterChildrenExt, RelmRemoveAllExt};
-use simple_moving_average::{SingleSumSMA, SMA};
+use simple_moving_average::{SMA, SingleSumSMA};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -282,8 +282,7 @@ impl FactoryComponent for FarmWidget {
 
                                         T
                                             .running_farmer_farm_non_fatal_error_tooltip(last_error)
-                                            .as_str()
-                                    },
+                                    }.as_str(),
                                     #[track = "self.changed_non_fatal_farming_error()"]
                                     set_visible: self.non_fatal_farming_error.is_some(),
                                 },
@@ -355,8 +354,7 @@ impl FactoryComponent for FarmWidget {
                                         farming,
                                     ),
                                 }
-                                    .as_str()
-                            },
+                            }.as_str(),
                         },
 
                         gtk::Spinner {

--- a/src/frontend/running/node.rs
+++ b/src/frontend/running/node.rs
@@ -1,5 +1,5 @@
-use crate::backend::node::{ChainInfo, SyncState, IN_PEERS, OUT_PEERS};
 use crate::backend::NodeNotification;
+use crate::backend::node::{ChainInfo, IN_PEERS, OUT_PEERS, SyncState};
 use crate::frontend::translations::{AsDefaultStr, T};
 use crate::icon_names;
 use bytesize::ByteSize;
@@ -7,7 +7,7 @@ use gtk::prelude::*;
 use parking_lot::Mutex;
 use relm4::prelude::*;
 use relm4::{Sender, ShutdownReceiver};
-use simple_moving_average::{SingleSumSMA, SMA};
+use simple_moving_average::{SMA, SingleSumSMA};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -195,7 +195,7 @@ impl Component for NodeView {
 
                             // TODO: Optimize rendering here, it will update on every block here
                             #[track = "model.changed_sync_state() || model.changed_best_block_number()"]
-                            set_label: &{
+                            set_label: {
                                 let sync_speed = if model.block_import_time.get_num_samples() > 0 {
                                      let sync_speed = 1.0 / model.block_import_time.get_average().as_secs_f32();
 
@@ -243,8 +243,7 @@ impl Component for NodeView {
                                         target,
                                         sync_speed,
                                     )
-                                    .as_str()
-                            },
+                            }.as_str(),
                         },
 
                         gtk::Spinner {

--- a/src/frontend/translations.rs
+++ b/src/frontend/translations.rs
@@ -24,8 +24,8 @@ mod messages {
 }
 
 use fluent_langneg::{
-    convert_vec_str_to_langids, convert_vec_str_to_langids_lossy, negotiate_languages,
-    NegotiationStrategy,
+    NegotiationStrategy, convert_vec_str_to_langids, convert_vec_str_to_langids_lossy,
+    negotiate_languages,
 };
 use fluent_static::fluent_bundle::FluentError;
 use fluent_static::{LanguageSpec, Message};


### PR DESCRIPTION
- Bumps substrate and subspace deps
- Bumps Rust toolchain to nightly used on subspace
- Migrated to 2024 rust edition as clippy warns are coming from subspace as it is using 2024 edition
- Remove lite-p2p patch as webrtc is made optional and its deps are not being included
- Patched libp2p and identity to our fork due to deps coming from different sources
- No logical changes but rather changes made to make clippy happy and errors coming due to 2024 edition.

Should be a straightforward review but focus on lock file if there is anything unexpected you see that I may have missed.


Running a local space-acres and everything seems okay with syncing with low peers as are seeing with latest pre-release on mainnet. 
