### PR TITLE
Revert "Remove reference to non-existent 'more information' from signature tooltip"

### DIFF
--- a/res/translations/de-DE/messages.ftl
+++ b/res/translations/de-DE/messages.ftl
@@ -125,7 +125,7 @@ running_farmer_next_reward_estimate =
         *[unknown] unbekannt
     }
 running_farmer_farm_tooltip = Klicken, um im Dateimanager zu öffnen
-running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} Erfolgreiche Reward-Signaturen
+running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} Erfolgreiche Reward-Signaturen, erweitere die Farm-Details, um mehr Informationen zu sehen.
 running_farmer_farm_auditing_performance_tooltip = Leistungsüberprüfung: Durchschnittliche Zeit {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, time limit {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_proving_performance_tooltip = Nachweis der Leistung: Durchschnittliche Zeit {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, time limit {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_non_fatal_error_tooltip = Ein nicht-kritischer Fehler beim Farming ist aufgetreten und wurde behoben, siehe Protokolle für weitere Details: {$error}

--- a/res/translations/en/messages.ftl
+++ b/res/translations/en/messages.ftl
@@ -126,7 +126,7 @@ running_farmer_next_reward_estimate =
         *[unknown] unknown
     }
 running_farmer_farm_tooltip = Click to open in file manager
-running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} successful reward signatures
+running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} successful reward signatures, expand farm details to see more information
 running_farmer_farm_auditing_performance_tooltip = Auditing performance: average time {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, time limit {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_proving_performance_tooltip = Proving performance: average time {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, time limit {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_non_fatal_error_tooltip = Non-fatal farming error happened and was recovered, see logs for more details: {$error}

--- a/res/translations/es/messages.ftl
+++ b/res/translations/es/messages.ftl
@@ -126,7 +126,7 @@ running_farmer_next_reward_estimate =
         *[unknown] Desconocido
     }
 running_farmer_farm_tooltip = Abrir sistema de archivos
-running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} firmas de recompensas existosas
+running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} firmas de recompensas existosas, obtén más información en los detalles de la granja
 running_farmer_farm_auditing_performance_tooltip = Auditando eficiencia: tiempo medio {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, tiempo límite {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_proving_performance_tooltip = Demostrando eficiencia: tiempo medio {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, tiempo límite {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_non_fatal_error_tooltip = Ha ocurrido un error pero se ha conseguido recuperar, mira la traza para más información: {$error}

--- a/res/translations/fr/messages.ftl
+++ b/res/translations/fr/messages.ftl
@@ -126,7 +126,7 @@ running_farmer_next_reward_estimate =
         *[unknown] inconnu
     }
 running_farmer_farm_tooltip = Cliquez pour ouvrir dans le gestionnaire de fichiers
-running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} signatures de récompense réussies
+running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} signatures de récompense réussies. Consultez les détails de la ferme pour plus d'informations
 running_farmer_farm_auditing_performance_tooltip = Performance de l'audit : temps moyen {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, limite de temps {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_proving_performance_tooltip = Performance de la preuve : temps moyen {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, limite de temps {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_non_fatal_error_tooltip = Une erreur est survenue lors du farming, mais elle a été corrigée. Consultez le journal pour plus de détails : {$error}

--- a/res/translations/ru-RU/messages.ftl
+++ b/res/translations/ru-RU/messages.ftl
@@ -126,7 +126,7 @@ running_farmer_next_reward_estimate =
         *[unknown] неизвестно
     }
 running_farmer_farm_tooltip = Нажмите, чтобы открыть в файловом менеджере
-running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} успешных подписей вознаграждения
+running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} успешных подписей вознаграждения. Смотрите детали фарма, чтобы получить подробную информацию
 running_farmer_farm_auditing_performance_tooltip = Эффективность аудита: среднее время {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, лимит времени {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_proving_performance_tooltip = Эффективность подтверждения: среднее время {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, лимит времени {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_non_fatal_error_tooltip = При фарминге произошла ошибка, которая была устранена. Более подробную информацию смотрите в журнале: {$error}

--- a/res/translations/sr-Latn-RS/messages.ftl
+++ b/res/translations/sr-Latn-RS/messages.ftl
@@ -130,7 +130,7 @@ running_farmer_next_reward_estimate =
         *[unknown] nepoznato
     }
 running_farmer_farm_tooltip = Kliknite da otvorite u upravitelju datotekama
-running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} uspešnih potpisa nagrada
+running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} uspešnih potpisa nagrada, proširi detalje farme da vidiš više informacija
 running_farmer_farm_auditing_performance_tooltip = Provera performansi: prosečno vreme {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, vremensko ograničenje {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_proving_performance_tooltip = Dokazivanje performansi: prosečno vreme {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}s, vremensko ograničenje {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}s
 running_farmer_farm_non_fatal_error_tooltip = Dogodila se ne-fatalna greška u farmovanju i uspešno je ispravljena, pogledajte dnevnik za više detalja: {$error}

--- a/res/translations/tr/messages.ftl
+++ b/res/translations/tr/messages.ftl
@@ -126,7 +126,7 @@ running_farmer_next_reward_estimate =
         *[unknown] bilinmiyor
     }
 running_farmer_farm_tooltip = Dosya yöneticisinde açmak için tıklayın
-running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} başarılı ödül imzaları
+running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} başarılı ödül imzaları, daha fazla bilgi için çiftlik detaylarını genişletin
 running_farmer_farm_auditing_performance_tooltip = Denetim performansı: ortalama süre {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}sn, zaman limiti {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}sn
 running_farmer_farm_proving_performance_tooltip = Kanıt performansı: ortalama süre {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}sn, zaman limiti {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}sn
 running_farmer_farm_non_fatal_error_tooltip = Riskli olmayan bir çiftçilik hatası oluştu ve düzeltildi, daha fazla detay için loglara bakın: {$error}

--- a/res/translations/uk-UA/messages.ftl
+++ b/res/translations/uk-UA/messages.ftl
@@ -124,7 +124,7 @@ running_farmer_next_reward_estimate =
         *[unknown] невідомо
     }
 running_farmer_farm_tooltip = Натисніть щоб відкрити в файловому менеджері
-running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} Успішні підписи винагороди
+running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} Успішні підписи винагороди, перегляньте деталі ферми, щоб побачити більше інформації
 running_farmer_farm_auditing_performance_tooltip = Аудит ефективності: середній час {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}с, ліміт часу {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}с
 running_farmer_farm_proving_performance_tooltip = Підтвердження ефективності: середній час {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}с, ліміт часу {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}с
 running_farmer_farm_non_fatal_error_tooltip = При фармінгу сталася помилка яка була усунена. Перегляньте журнали для отримання додаткової інформації: {$error}

--- a/res/translations/zh-CN/messages.ftl
+++ b/res/translations/zh-CN/messages.ftl
@@ -126,7 +126,7 @@ running_farmer_next_reward_estimate =
         *[unknown] 未知
     }
 running_farmer_farm_tooltip = 在文件管理器中打开
-running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} 奖励签名成功
+running_farmer_farm_reward_signatures_tooltip = {$successful_signatures}/{$total_signatures} 奖励签名成功，打开农场查看更多信息
 running_farmer_farm_auditing_performance_tooltip = 审计性能: 平均时长 {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}秒, 时间限制 {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}秒
 running_farmer_farm_proving_performance_tooltip = 证明性能: 平均时长 {NUMBER($a_average_time, minimumFractionDigits: 2, maximumFractionDigits: 2)}秒, 时间限制 {NUMBER($b_time_timit, minimumFractionDigits: 2, maximumFractionDigits: 2)}秒
 running_farmer_farm_non_fatal_error_tooltip = 非致命错误发生并已经恢复，在日志中查看更多信息: {$error}


### PR DESCRIPTION
Reverts autonomys/space-acres#378

The information actually exists, it's to the right of the signature indicator.