### PR TITLE
Update subspace for piece cache slot fix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,6 +96,7 @@ jobs:
           if (Compare-Object -ReferenceObject (Get-Content -Path res\windows\wix\expected-dlls.log) -DifferenceObject (Get-Content -Path actual-dlls.log)) {
             Write-Output "Expected DLLs:"
             Get-Content res\windows\wix\expected-dlls.log
+            Write-Output "`r`n"
             Write-Output "Actual DLLs:"
             Get-Content actual-dlls.log
             Throw "Actual DLLs do not match expected"
@@ -214,6 +215,7 @@ jobs:
           if (Compare-Object -ReferenceObject (Get-Content -Path res\windows\wix\expected-pixbuf-loaders.log) -DifferenceObject (Get-Content -Path actual-pixbuf-loaders.log)) {
             Write-Output "Expected pixbuf -loaders:"
             Get-Content res\windows\wix\expected-pixbuf-loaders.log
+            Write-Output "`r`n"
             Write-Output "`r`nActual pixbuf loaders:"
             Get-Content actual-pixbuf-loaders.log
             Throw "Actual pixbuf loaders do not match expected"
@@ -224,6 +226,7 @@ jobs:
           if (Compare-Object -ReferenceObject (Get-Content -Path res\windows\wix\expected-dlls.log) -DifferenceObject (Get-Content -Path actual-dlls.log)) {
             Write-Output "Expected DLLs:"
             Get-Content res\windows\wix\expected-dlls.log
+            Write-Output "`r`n"
             Write-Output "`r`nActual DLLs:"
             Get-Content actual-dlls.log
             Throw "Actual DLLs do not match expected"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11724,6 +11724,7 @@ dependencies = [
  "subspace-farmer-components",
  "subspace-kzg",
  "subspace-networking",
+ "subspace-process",
  "subspace-proof-of-space",
  "subspace-proof-of-space-gpu",
  "subspace-rpc-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,7 +1990,7 @@ checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "domain-block-preprocessor",
  "fp-account",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "domain-block-builder"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "hash-db",
  "hex-literal",
@@ -2501,7 +2501,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "fp-account",
  "frame-support",
@@ -9368,9 +9368,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-trait",
+ "bytesize",
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -9409,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -9444,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "sc-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -9817,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "core_affinity",
  "derive_more 1.0.0",
@@ -10052,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10079,12 +10080,12 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 
 [[package]]
 name = "sc-subspace-sync-common"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10792,7 +10793,7 @@ dependencies = [
 [[package]]
 name = "sp-auto-id"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10816,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "sp-block-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -10926,7 +10927,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-trait",
  "log",
@@ -11042,7 +11043,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -11051,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-sudo"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11062,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "blake2 0.10.6",
  "domain-runtime-primitives",
@@ -11094,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "sp-domains-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "domain-block-builder",
  "domain-block-preprocessor",
@@ -11130,7 +11131,7 @@ dependencies = [
 [[package]]
 name = "sp-evm-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -11145,7 +11146,7 @@ dependencies = [
 [[package]]
 name = "sp-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11246,7 +11247,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -11268,7 +11269,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger-host-functions"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "domain-block-preprocessor",
  "parity-scale-codec",
@@ -11325,7 +11326,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "sp-api",
  "subspace-core-primitives",
@@ -11512,7 +11513,7 @@ dependencies = [
 [[package]]
 name = "sp-subspace-mmr"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11897,7 +11898,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
@@ -11912,7 +11913,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "blake3",
  "bytes",
@@ -11931,7 +11932,7 @@ dependencies = [
 [[package]]
 name = "subspace-data-retrieval"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11949,7 +11950,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "kzg",
  "rust-kzg-blst",
@@ -11960,7 +11961,7 @@ dependencies = [
 [[package]]
 name = "subspace-fake-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "domain-runtime-primitives",
  "frame-support",
@@ -11990,8 +11991,8 @@ dependencies = [
 
 [[package]]
 name = "subspace-farmer"
-version = "0.1.1"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+version = "0.1.2"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -12029,6 +12030,7 @@ dependencies = [
  "subspace-farmer-components",
  "subspace-kzg",
  "subspace-networking",
+ "subspace-process",
  "subspace-proof-of-space",
  "subspace-proof-of-space-gpu",
  "subspace-rpc-primitives",
@@ -12047,7 +12049,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -12080,7 +12082,7 @@ dependencies = [
 [[package]]
 name = "subspace-kzg"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "derive_more 1.0.0",
  "kzg",
@@ -12093,19 +12095,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "subspace-logging"
-version = "0.0.1"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
-dependencies = [
- "supports-color",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "subspace-metrics"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "actix-web",
  "prometheus",
@@ -12116,7 +12108,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -12140,8 +12132,8 @@ dependencies = [
  "rand 0.8.5",
  "schnellru",
  "subspace-core-primitives",
- "subspace-logging",
  "subspace-metrics",
+ "subspace-process",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -12151,9 +12143,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "subspace-process"
+version = "0.0.1"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
+dependencies = [
+ "fdlimit",
+ "futures",
+ "supports-color",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "blake3",
  "chacha20",
@@ -12169,7 +12174,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space-gpu"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "blst",
  "cc",
@@ -12182,7 +12187,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "aes 0.9.0-pre.2",
  "cpufeatures",
@@ -12193,7 +12198,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -12206,7 +12211,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12226,7 +12231,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -12317,7 +12322,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=951de7a0f41f82979b75370e6eec1ebcca853aeb#951de7a0f41f82979b75370e6eec1ebcca853aeb"
+source = "git+https://github.com/subspace/subspace?rev=7ce6f74032910338314c2c9b6e4a7833530467dc#7ce6f74032910338314c2c9b6e4a7833530467dc"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "7ce6f74
 subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
 subspace-kzg = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
 subspace-networking = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-process = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
 subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
 subspace-proof-of-space-gpu = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc", optional = true }
 subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,13 +72,13 @@ reqwest = { version = "0.12.8", default-features = false, features = ["json", "r
 sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
 sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
 sc-consensus-slots = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
-sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
+sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
 sc-network-types = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
 sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
 sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
 sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
 sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
 schnellru = "0.2.4"
 semver = "1.0.23"
@@ -87,24 +87,24 @@ serde_json = "1.0.133"
 simple_moving_average = "1.0.2"
 sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
 sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
-sp-objects = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
+sp-objects = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
 sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "e831132867930ca90a7088c7246301ab29f015ba", default-features = false }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-data-retrieval = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-fake-runtime-api = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb", default-features = false }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-kzg = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-proof-of-space-gpu = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb", optional = true }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "951de7a0f41f82979b75370e6eec1ebcca853aeb" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-data-retrieval = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-fake-runtime-api = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc", default-features = false }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-kzg = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-proof-of-space-gpu = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc", optional = true }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "7ce6f74032910338314c2c9b6e4a7833530467dc" }
 sys-locale = "0.3.1"
 tempfile = "3.13.0"
 thiserror = "2.0.1"

--- a/res/windows/wix/expected-dlls.log
+++ b/res/windows/wix/expected-dlls.log
@@ -37,7 +37,7 @@ pcre2-32-0.dll
 pcre2-8-0.dll
 pcre2-posix-3.dll
 pixman-1-0.dll
-pkgconf-6.dll
+pkgconf-7.dll
 rsvg-2-2.dll
 textstyle.dll
 tiff.dll

--- a/res/windows/wix/space-acres.wxs
+++ b/res/windows/wix/space-acres.wxs
@@ -237,8 +237,8 @@
                         <Component Id='gtk4_pixman_1_0.dll' Guid='9f6dff89-ea6e-4355-9863-f076e915697d'>
                             <File Id='pixman_1_0.dll' Name='pixman-1-0.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\pixman-1-0.dll' />
                         </Component>
-                        <Component Id='gtk4_pkgconf_6.dll' Guid='2b0ab36a-d1d0-427f-a63c-6dfd513b8b82'>
-                            <File Id='pkgconf_6.dll' Name='pkgconf-6.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\pkgconf-6.dll' />
+                        <Component Id='gtk4_pkgconf_7.dll' Guid='edc282a6-ee0e-4ae0-a080-c78cd79ab047'>
+                            <File Id='pkgconf_7.dll' Name='pkgconf-7.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\pkgconf-7.dll' />
                         </Component>
                         <Component Id='gtk4_rsvg_2_2.dll' Guid='c45c78c2-1b52-4bb8-b165-64229cacb357'>
                             <File Id='rsvg_2_2.dll' Name='rsvg-2-2.dll' DiskId='1' Source='$(var.CargoTargetDir)\wix\gtk4\bin\rsvg-2-2.dll' />
@@ -394,7 +394,7 @@
             <ComponentRef Id='gtk4_pcre2_8_0.dll'/>
             <ComponentRef Id='gtk4_pcre2_posix_3.dll'/>
             <ComponentRef Id='gtk4_pixman_1_0.dll'/>
-            <ComponentRef Id='gtk4_pkgconf_6.dll'/>
+            <ComponentRef Id='gtk4_pkgconf_7.dll'/>
             <ComponentRef Id='gtk4_rsvg_2_2.dll'/>
             <ComponentRef Id='gtk4_textstyle.dll'/>
             <ComponentRef Id='gtk4_tiff.dll'/>

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -36,13 +36,13 @@ use subspace_farmer::farmer_cache::{FarmerCache, FarmerCacheWorker, FarmerCaches
 use subspace_farmer::farmer_piece_getter::piece_validator::SegmentCommitmentPieceValidator;
 use subspace_farmer::farmer_piece_getter::{DsnCacheRetryPolicy, FarmerPieceGetter};
 use subspace_farmer::single_disk_farm::SingleDiskFarm;
-use subspace_farmer::utils::run_future_in_dedicated_thread;
 use subspace_kzg::Kzg;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::libp2p::identity::ed25519::{Keypair, SecretKey};
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::utils::piece_provider::PieceProvider;
 use subspace_networking::{Node, NodeRunner};
+use subspace_process::run_future_in_dedicated_thread;
 use subspace_runtime_primitives::Balance;
 use tokio::fs;
 use tokio::fs::OpenOptions;

--- a/src/backend/farmer.rs
+++ b/src/backend/farmer.rs
@@ -40,12 +40,13 @@ use subspace_farmer::single_disk_farm::{
     SingleDiskFarm, SingleDiskFarmError, SingleDiskFarmOptions,
 };
 use subspace_farmer::utils::{
-    AsyncJoinOnDrop, create_plotting_thread_pool_manager, recommended_number_of_farming_threads,
-    run_future_in_dedicated_thread, thread_pool_core_indices,
+    create_plotting_thread_pool_manager, recommended_number_of_farming_threads,
+    thread_pool_core_indices,
 };
 use subspace_farmer_components::plotting::PlottedSector;
 use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_kzg::Kzg;
+use subspace_process::{AsyncJoinOnDrop, run_future_in_dedicated_thread};
 use thread_priority::ThreadPriority;
 use tokio::sync::watch;
 use tracing::{Instrument, debug, error, info, info_span};

--- a/src/backend/farmer.rs
+++ b/src/backend/farmer.rs
@@ -54,7 +54,7 @@ use tracing::{Instrument, debug, error, info, info_span};
 /// Minimal cache percentage, there is no need in setting it higher
 pub(super) const CACHE_PERCENTAGE: NonZeroU8 = NonZeroU8::MIN;
 /// NOTE: for large gaps between the plotted part and the end of the file plot cache will result in
-/// very long period of writing zeroes on Windows, see https://stackoverflow.com/q/78058306/3806795
+/// very long period of writing zeroes on Windows, see <https://stackoverflow.com/q/78058306/3806795>
 const MAX_SPACE_PLEDGED_FOR_PLOT_CACHE_ON_WINDOWS: u64 = ByteSize::tib(7).as_u64();
 const FARM_ERROR_PRINT_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_PLOTTING_SECTORS_PER_FARM: NonZeroUsize = NonZeroUsize::new(2).expect("Not zero; qed");

--- a/src/backend/farmer/direct_node_client.rs
+++ b/src/backend/farmer/direct_node_client.rs
@@ -610,6 +610,13 @@ where
         + 'static,
     Client::Api: SubspaceApi<Block, PublicKey> + ObjectsApi<Block> + 'static,
 {
+    async fn cached_segment_headers(
+        &self,
+        segment_indexes: Vec<SegmentIndex>,
+    ) -> anyhow::Result<Vec<Option<SegmentHeader>>> {
+        self.segment_headers(segment_indexes).await
+    }
+
     async fn last_segment_headers(&self, limit: u32) -> anyhow::Result<Vec<Option<SegmentHeader>>> {
         let last_segment_index = self
             .segment_headers_store

--- a/src/backend/farmer/maybe_node_client.rs
+++ b/src/backend/farmer/maybe_node_client.rs
@@ -105,6 +105,16 @@ impl NodeClient for MaybeNodeClient {
 
 #[async_trait::async_trait]
 impl NodeClientExt for MaybeNodeClient {
+    async fn cached_segment_headers(
+        &self,
+        segment_indexes: Vec<SegmentIndex>,
+    ) -> anyhow::Result<Vec<Option<SegmentHeader>>> {
+        match &*self.inner.load() {
+            Some(inner) => inner.cached_segment_headers(segment_indexes).await,
+            None => Err(anyhow::anyhow!("Inner node client not injected yet")),
+        }
+    }
+
     async fn last_segment_headers(&self, limit: u32) -> anyhow::Result<Vec<Option<SegmentHeader>>> {
         match &*self.inner.load() {
             Some(inner) => inner.last_segment_headers(limit).await,

--- a/src/backend/networking.rs
+++ b/src/backend/networking.rs
@@ -253,7 +253,10 @@ where
                                 "Segment headers request received."
                             );
 
-                            node_client.segment_headers(segment_indexes).await
+                            // Space Acres uses a DirectNodeClient, which does not attempt to
+                            // update segment headers while accessing them. But we use the cached
+                            // method for consistency with subspace-farmer.
+                            node_client.cached_segment_headers(segment_indexes).await
                         }
                         SegmentHeaderRequest::LastSegmentHeaders { mut limit } => {
                             if limit > SEGMENT_HEADERS_LIMIT {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::available_parallelism;
 use std::time::{Duration, Instant};
 use std::{env, fs, io, process};
-use subspace_farmer::utils::run_future_in_dedicated_thread;
+use subspace_process::run_future_in_dedicated_thread;
 use subspace_proof_of_space::chia::ChiaTable;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::filter::LevelFilter;


### PR DESCRIPTION
This PR updates subspace to bring in the piece cache slot fix:
- https://github.com/autonomys/subspace/pull/3677

We also moved some code around and added new trait methods in `subspace` in:
- https://github.com/autonomys/subspace/pull/3660
- https://github.com/autonomys/subspace/pull/3659
- https://github.com/autonomys/subspace/pull/3669
- https://github.com/autonomys/subspace/pull/3678

This PR fixes those imports and adds the new trait methods. It also documents why the security fixes in https://github.com/autonomys/subspace/pull/3660 weren't needed here.

~~It's a draft until all those `subspace` PRs merge, then I'll update the subspace dependency to the main branch.
I'm posting it now so these fixes are ready, even if I'm away.~~