### PR TITLE
Upgrade subspace to mainnet-2026-jun-14, bump to 0.2.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,7 +2214,7 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "domain-block-preprocessor",
  "fp-account",
@@ -2800,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "domain-block-builder"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "hash-db",
  "hex-literal 1.1.0",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -2855,7 +2855,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "fp-account",
  "frame-support",
@@ -9893,7 +9893,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-trait",
  "bytesize 2.3.1",
@@ -9936,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -9971,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "sc-domains"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-primitives-proof-size-hostfunction",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "core_affinity",
  "derive_more 2.1.1",
@@ -10567,7 +10567,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10594,12 +10594,12 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 
 [[package]]
 name = "sc-subspace-sync-common"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "futures",
  "hex",
@@ -11396,7 +11396,7 @@ dependencies = [
 [[package]]
 name = "sp-auto-id"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11420,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "sp-block-fees"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -11529,7 +11529,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-trait",
  "log",
@@ -11647,7 +11647,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -11656,7 +11656,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-sudo"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11667,7 +11667,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "blake2 0.10.6",
  "domain-runtime-primitives",
@@ -11700,7 +11700,7 @@ dependencies = [
 [[package]]
 name = "sp-domains-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "domain-block-builder",
  "domain-block-preprocessor",
@@ -11736,7 +11736,7 @@ dependencies = [
 [[package]]
 name = "sp-evm-tracker"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -11751,7 +11751,7 @@ dependencies = [
 [[package]]
 name = "sp-executive"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11852,7 +11852,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -11874,7 +11874,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger-host-functions"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "domain-block-preprocessor",
  "parity-scale-codec",
@@ -11931,7 +11931,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "sp-api",
  "subspace-core-primitives",
@@ -12119,7 +12119,7 @@ dependencies = [
 [[package]]
 name = "sp-subspace-mmr"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12535,7 +12535,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
@@ -12550,7 +12550,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "blake3",
  "bytes",
@@ -12569,7 +12569,7 @@ dependencies = [
 [[package]]
 name = "subspace-data-retrieval"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12587,7 +12587,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "kzg",
  "rust-kzg-blst",
@@ -12598,7 +12598,7 @@ dependencies = [
 [[package]]
 name = "subspace-fake-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "domain-runtime-primitives",
  "frame-support",
@@ -12628,8 +12628,8 @@ dependencies = [
 
 [[package]]
 name = "subspace-farmer"
-version = "0.1.10"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+version = "0.1.11"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -12686,7 +12686,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -12719,7 +12719,7 @@ dependencies = [
 [[package]]
 name = "subspace-kzg"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "derive_more 2.1.1",
  "kzg",
@@ -12734,7 +12734,7 @@ dependencies = [
 [[package]]
 name = "subspace-metrics"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "actix-web",
  "prometheus",
@@ -12745,7 +12745,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -12782,7 +12782,7 @@ dependencies = [
 [[package]]
 name = "subspace-process"
 version = "0.0.1"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "console",
  "fdlimit",
@@ -12796,7 +12796,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "ab-chacha8",
  "blake3",
@@ -12810,7 +12810,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space-gpu"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "blst",
  "cc",
@@ -12823,7 +12823,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "aes 0.9.1",
  "cpufeatures 0.3.0",
@@ -12834,7 +12834,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -12847,7 +12847,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12867,7 +12867,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
@@ -12957,7 +12957,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/autonomys/subspace?rev=7818df416740a7f75cc822047114914b1bbe3f62#7818df416740a7f75cc822047114914b1bbe3f62"
+source = "git+https://github.com/autonomys/subspace?rev=b3f2859d528637eaa7d2e6a36b84ef009f79ab67#b3f2859d528637eaa7d2e6a36b84ef009f79ab67"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12264,7 +12264,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "space-acres"
 description = "Space Acres is an opinionated GUI application for farming on Autonomys Network"
 license = "0BSD"
-version = "0.2.20"
+version = "0.2.21"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/autonomys/space-acres"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,13 +73,13 @@ reqwest = { version = "0.12.8", default-features = false, features = ["json", "r
 sc-client-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sc-client-db = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sc-consensus-slots = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sc-consensus-subspace = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
+sc-consensus-subspace = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
 sc-network = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sc-network-types = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sc-rpc = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sc-service = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sc-storage-monitor = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
+sc-subspace-chain-specs = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
 sc-utils = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 schnellru = "0.2.4"
 semver = "1.0.23"
@@ -88,25 +88,25 @@ serde_json = "1.0.133"
 simple_moving_average = "1.0.2"
 sp-api = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
 sp-consensus = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-consensus-subspace = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
+sp-consensus-subspace = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
 sp-core = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-sp-objects = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
+sp-objects = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
 sp-runtime = { git = "https://github.com/autonomys/polkadot-sdk", rev = "8304f8852018c9b2d69071449e988d6e63e4122c", default-features = false }
-subspace-archiving = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-core-primitives = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-data-retrieval = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-erasure-coding = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-fake-runtime-api = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-farmer = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62", default-features = false }
-subspace-farmer-components = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-kzg = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-networking = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-process = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-proof-of-space = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-proof-of-space-gpu = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62", optional = true }
-subspace-rpc-primitives = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-runtime-primitives = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
-subspace-service = { git = "https://github.com/autonomys/subspace", rev = "7818df416740a7f75cc822047114914b1bbe3f62" }
+subspace-archiving = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-core-primitives = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-data-retrieval = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-erasure-coding = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-fake-runtime-api = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-farmer = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67", default-features = false }
+subspace-farmer-components = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-kzg = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-networking = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-process = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-proof-of-space = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-proof-of-space-gpu = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67", optional = true }
+subspace-rpc-primitives = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-runtime-primitives = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
+subspace-service = { git = "https://github.com/autonomys/subspace", rev = "b3f2859d528637eaa7d2e6a36b84ef009f79ab67" }
 sys-locale = "0.3.1"
 tempfile = "3.13.0"
 thiserror = "2.0.1"


### PR DESCRIPTION
Tracks the subspace mainnet-2026-jun-14 release - a client-only update that fixes a proof-of-space piece-read regression (farmers were hitting "Invalid scalar" errors serving pieces to peers; no replot needed).

